### PR TITLE
Minor fix: Update left over reference to pyro (vs. sumo)

### DIFF
--- a/labs/yocto-first-build/yocto-first-build.tex
+++ b/labs/yocto-first-build/yocto-first-build.tex
@@ -23,7 +23,7 @@ sudo apt install bc build-essential chrpath cpio diffstat gawk git python texinf
 
 \section{Download Yocto}
 
-Download the \code{pyro} version of Poky and apply a custom patch:
+Download the \code{sumo} version of Poky and apply a custom patch:
 \begin{verbatim}
 git clone git://git.yoctoproject.org/poky.git
 cd $HOME/yocto-labs/poky


### PR DESCRIPTION
There was a left over reference to pyro in the first lab.