### PR TITLE
use PKG_CONFIG_LIBDIR instead of PKG_CONFIG_PATH

### DIFF
--- a/labs/sysdev-thirdparty/sysdev-thirdparty.tex
+++ b/labs/sysdev-thirdparty/sysdev-thirdparty.tex
@@ -789,7 +789,7 @@ for libraries in the default paths.
 
 So, now, we must tell {\em pkg-config} to look inside the
 \code{/usr/lib/pkgconfig/} directory of our {\em staging} space. This
-is done through the \code{PKG_CONFIG_PATH} environment variable, as
+is done through the \code{PKG_CONFIG_LIBDIR} environment variable, as
 explained in the manual page of \code{pkg-config}.
 
 Moreover, the \code{.pc} files contain references to paths. For
@@ -812,14 +812,14 @@ but relative to our {\em staging} space. This can be done using the
 \code{PKG_CONFIG_SYSROOT_DIR} environment variable.
 
 Then, let's run the configuration of the vorbis-tools again, passing
-the \code{PKG_CONFIG_PATH} and \code{PKG_CONFIG_SYSROOT_DIR}
+the \code{PKG_CONFIG_LIBDIR} and \code{PKG_CONFIG_SYSROOT_DIR}
 environment variables:
 
 \small
 \begin{verbatim}
 LDFLAGS=-L$HOME/embedded-linux-labs/thirdparty/staging/usr/lib \
 CPPFLAGS=-I$HOME/embedded-linux-labs/thirdparty/staging/usr/include \
-PKG_CONFIG_PATH=$HOME/embedded-linux-labs/thirdparty/staging/usr/lib/pkgconfig \
+PKG_CONFIG_LIBDIR=$HOME/embedded-linux-labs/thirdparty/staging/usr/lib/pkgconfig \
 PKG_CONFIG_SYSROOT_DIR=$HOME/embedded-linux-labs/thirdparty/staging \
 CC=arm-linux-gcc \
 ./configure --host=arm-linux --prefix=/usr
@@ -868,7 +868,7 @@ Add this to the \code{configure} command line to get
 \begin{verbatim}
 LDFLAGS=-L$HOME/embedded-linux-labs/thirdparty/staging/usr/lib \
 CPPFLAGS=-I$HOME/embedded-linux-labs/thirdparty/staging/usr/include \
-PKG_CONFIG_PATH=$HOME/embedded-linux-labs/thirdparty/staging/usr/lib/pkgconfig \
+PKG_CONFIG_LIBDIR=$HOME/embedded-linux-labs/thirdparty/staging/usr/lib/pkgconfig \
 PKG_CONFIG_SYSROOT_DIR=$HOME/embedded-linux-labs/thirdparty/staging \
 LIBS=-lm \
 CC=arm-linux-gcc \

--- a/slides/sysdev-embedded-linux/sysdev-embedded-linux.tex
+++ b/slides/sysdev-embedded-linux/sysdev-embedded-linux.tex
@@ -1119,7 +1119,7 @@ Contents of \code{usr/lib} after installation of {\em libpng} and {\em
   \item By default, \code{pkg-config} looks in \code{/usr/lib/pkgconfig} for
     the \code{*.pc} files, and assumes that the paths in these files
     are correct.
-  \item \code{PKG_CONFIG_PATH} allows to set another location for the
+  \item \code{PKG_CONFIG_LIBDIR} allows to set another location for the
     \code{*.pc} files and \code{PKG_CONFIG_SYSROOT_DIR} to prepend a
     prefix to the paths mentioned in the \code{.pc} files.
   \end{itemize}
@@ -1140,7 +1140,7 @@ Contents of \code{usr/lib} after installation of {\em libpng} and {\em
     include the absolute paths of the libraries:\\
     \code{- libdir='/usr/lib'}\\
     \code{+ libdir='/my/build/space/usr/lib}'
-  \item The \code{PKG_CONFIG_PATH} environment variable must be set to
+  \item The \code{PKG_CONFIG_LIBDIR} environment variable must be set to
     the location of the .pc files and the
     \code{PKG_CONFIG_SYSROOT_DIR} variable must be set to the build
     space directory.


### PR DESCRIPTION
_PATH add new dir to the search path, and _LIBDIR replaces path.
When crosscompiling we should not use any .pc file from the
native system thus we should use PKG_CONFIG_LIBDIR.