### PR TITLE
Refer to the online manual as crosstool-ng dev version does not ship docs.

### DIFF
--- a/labs/sysdev-toolchain/sysdev-toolchain.tex
+++ b/labs/sysdev-toolchain/sysdev-toolchain.tex
@@ -37,8 +37,8 @@ git checkout eb65ba65
 
 We can either install Crosstool-ng globally on the system, or keep it
 locally in its download directory. We'll choose the latter
-solution. As documented in
-\code{docs/2 - Installing crosstool-NG.txt}, do:
+solution. As documented at
+\url{http://crosstool-ng.github.io/docs/install/#hackers-way}, do:
 
 \begin{verbatim}
 ./bootstrap


### PR DESCRIPTION
The lab text mentions a documentation file that only exists in release
tarballs. Better point to the online manual as the name of the file
changed as well.

