### PR TITLE
buildroot: S30usbgadget: Host addr mismatch

### DIFF
--- a/lab-data/buildroot/buildroot-rootfs/S30usbgadget
+++ b/lab-data/buildroot/buildroot-rootfs/S30usbgadget
@@ -28,7 +28,7 @@ mkdir configs/c.1
 mkdir configs/c.1/strings/0x409
 echo Conf 1 > configs/c.1/strings/0x409/configuration
 echo 120 > configs/c.1/MaxPower
-echo "06:32:9b:a9:9d:a5" > functions/ecm.usb0/host_addr
+echo "f8:dc:7a:00:00:01" > functions/ecm.usb0/host_addr
 ln -s functions/ecm.usb0 configs/c.1
 echo musb-hdrc.0 > UDC
 cd ${OLDPWD}


### PR DESCRIPTION
The host address does not match the one in the buildroot-labs.pdf 
page 14.

Signed-off-by: Mircea Caprioru <mircea.caprioru@gmail.com>