### PR TITLE
yocto: fix device-tree name for stm32mp157a-dk1 board

### DIFF
--- a/labs/yocto-custom-machine/yocto-custom-machine.tex
+++ b/labs/yocto-custom-machine/yocto-custom-machine.tex
@@ -53,7 +53,7 @@ This \code{bootlinlabs} machine needs:
     Micro to work properly:
 \begin{verbatim}
 BOOTSCHEME_LABELS += "trusted"
-STM32MP_DT_FILES_DK += "stm32mp157c-dk1"
+STM32MP_DT_FILES_DK += "stm32mp157a-dk1"
 ST_KERNEL_LOADADDR   = "0xC2000040"
 FLASHLAYOUT_CONFIG_LABELS += "sdcard"
 \end{verbatim}


### PR DESCRIPTION
Fixes: 6073481a4c4f0812aee13ba1d582a6f2e5e9e25d ("yocto: Update custom machine for -DK1 board")

Signed-off-by: Pierre-Jean Texier <pjtexier@koncepto.io>