### PR TITLE
Fix Linux kernel version reference

### DIFF
--- a/labs/buildroot-basic/buildroot-basic.tex
+++ b/labs/buildroot-basic/buildroot-basic.tex
@@ -184,7 +184,7 @@ Now, let's do the configuration:
       Blob} option. At
     \url{https://git.kernel.org/cgit/linux/kernel/git/torvalds/linux.git/tree/arch/arm/boot/dts/?id=v5.4},
     you can see the list of all Device Tree files available in the
-    4.19 Linux kernel (note: the Device Tree files for boards use the
+    5.4 Linux kernel (note: the Device Tree files for boards use the
     \code{.dts} extension). The one for the BeagleBone Black Wireless
     is \code{am335x-boneblack-wireless.dts}. Even if talking about
     Device Tree is beyond the scope of this training, feel free to


### PR DESCRIPTION
Text and link should refer to the same kernel version (5.4)