### PR TITLE
kernel labs: add 'Setting up the TFTP server' section.

### DIFF
--- a/labs/kernel-board-setup/kernel-board-setup.tex
+++ b/labs/kernel-board-setup/kernel-board-setup.tex
@@ -210,13 +210,24 @@ which is so much easier to use:
 nmcli con add type ethernet ifname enxf8dc7a000001 ip4 192.168.0.1/24
 \end{verbatim}
 
-\section{Testing the network connection}
+\section{Setting up the TFTP server}
 
 Let's install a TFTP server on your development workstation:
 
 \begin{verbatim}
 sudo apt install tftpd-hpa
 \end{verbatim}
+
+Once the package is installed, open \code{/etc/default/tftpd-hpa} with your favorite
+text editor, and make sure that the TFTP directory is set to \code{TFTP_DIRECTORY=/var/lib/tftpboot/}.
+
+If you need to make a change, then save the changes and restart the TFTP server:
+
+\begin{verbatim}
+sudo /etc/init.d/tftpd-hpa restart
+\end{verbatim}
+
+\section{Testing the network connection}
 
 You can then test the TFTP connection.  First, put a small text
 file in \code{/var/lib/tftpboot}. Then, from U-Boot, do:


### PR DESCRIPTION
The TFTP directory is by default set to **/srv/tftp** on some (newer) systems. @michaelopdenacker 