### PR TITLE
Added missing package to README

### DIFF
--- a/README
+++ b/README
@@ -8,7 +8,7 @@ texlive-latex-base texlive-latex-extra texlive-font-utils dia \
 python-pygments python3-pygments texlive-fonts-recommended \
 texlive-fonts-extra make texlive-xetex texlive-extra-utils \
 fonts-inconsolata fonts-liberation ttf-ubuntu-font-family \
-xfonts-scalable lmodern texlive-science
+xfonts-scalable lmodern texlive-science texlive-plain-generic
 
 Then, run 'make help' to see what available targets are.
 


### PR DESCRIPTION
1. Installed packages as described in README
2. `make all` failed with error:

```
! LaTeX Error: File `ulem.sty' not found.
```

Reproduced on Linux Mint 19.3 (5.4.0-54).

According to [Stack Exchange](https://tex.stackexchange.com/questions/489543/ubuntu-18-04-lts-texlive-2018-latex-error-file-ulem-sty-not-found), the simple solution is to add texlive-plain-generic package to the system.

Signed-off-by: Marek Gawryszewski <marek.gawryszewski@protonmail.com>