### PR TITLE
slides/kernel-driver-development-processes: fix typo in thread states…

### DIFF
--- a/slides/kernel-driver-development-processes/threads-life.dia
+++ b/slides/kernel-driver-development-processes/threads-life.dia
@@ -457,7 +457,7 @@ EXIT_ZOMBIE#</dia:string>
         <dia:composite type="text">
           <dia:attribute name="string">
             <dia:string>#
-TASK_RUNNING#</dia:string>
+TASK_RUNNABLE#</dia:string>
           </dia:attribute>
           <dia:attribute name="font">
             <dia:font family="Latin Modern Sans" style="0" name="Courier"/>


### PR DESCRIPTION
Hello,

There is likely a typo regarding the thread states diagram in the _Linux Kernel and Driver
Development Training_ slide 305, where TASK_RUNNING appears twice whereas TASK_RUNNABLE is absent.

Best regards,

J-Ph D