### PR TITLE
Kernel compiling: use arm-linux- instead of riscv64-linux- with ccache

### DIFF
--- a/slides/sysdev-kernel-building/sysdev-kernel-building.tex
+++ b/slides/sysdev-kernel-building/sysdev-kernel-building.tex
@@ -382,7 +382,7 @@ CONFIG_NTFS_RW=y
     \item No need to run as root!
     \item To {\bf re}compile faster (7x according to some benchmarks),\\
 	  use the \code{ccache} compiler cache:\\
-          \code{export CROSS_COMPILE="ccache riscv64-linux-"}
+          \code{export CROSS_COMPILE="ccache arm-linux-"}
   \end{itemize}
   \column{0.3\textwidth}
     \includegraphics[width=\textwidth]{slides/sysdev-kernel-building/parallel-make-benefits.pdf}


### PR DESCRIPTION
Since all the previous explanations use arm-linux- cross-compiler prefix
let's use it here instead of riscv64-linux- prefix.

Signed-off-by: Giulio Benetti <giulio.benetti@benettiengineering.com>