### PR TITLE
Change description of the `-b` option of bitbake.

### DIFF
--- a/slides/yocto-advanced/yocto-advanced.tex
+++ b/slides/yocto-advanced/yocto-advanced.tex
@@ -289,8 +289,8 @@ IMAGE_INSTALL = "busybox mtd-utils"
       \item[\code{-f}] force the given task to be run by removing its
         stamp file
       \item[\code{world}] keyword for all recipes
-      \item[\code{-b <recipe>}] execute tasks from the given
-        \code{recipe} (without resolving dependencies).
+      \item[\code{-b <buildfile>}] execute tasks from the given
+        \code{buildfile} (without resolving dependencies).
     \end{description}
   \end{itemize}
 \end{frame}


### PR DESCRIPTION
The `-b` option of bitbake takes buildfile as parameter instead of the name of a recipe.