### PR TITLE
Updated slides for Buildroot strip options.

### DIFF
--- a/slides/buildroot-appdev/buildroot-appdev.tex
+++ b/slides/buildroot-appdev/buildroot-appdev.tex
@@ -320,8 +320,11 @@ LINUX_OVERRIDE_SRCDIR = $(HOME)/projects/linux
     \item Sub-options allow to control the amount of debugging symbols
       (i.e. gcc options \code{-g1}, \code{-g2} and \code{-g3}).
     \end{itemize}
-  \item The \code{BR2_STRIP_none} and \code{BR2_STRIP_strip} options
-    allow to disable or enable stripping of binaries on the target.
+  \item The \code{BR2_STRIP_strip} option
+    allows to disable or enable stripping of binaries on the target.
+    \begin{itemize}
+    \item Enabled by default.
+    \end{itemize}
   \end{itemize}
 \end{frame}
 
@@ -334,7 +337,7 @@ LINUX_OVERRIDE_SRCDIR = $(HOME)/projects/linux
     \item stripped binaries in \code{$(TARGET_DIR)}
     \item Appropriate for {\bf remote debugging}
     \end{itemize}
-  \item With \code{BR2_ENABLE_DEBUG=y} and \code{BR2_STRIP_none=y}
+  \item With \code{BR2_ENABLE_DEBUG=y} and \code{BR2_STRIP_strip=n}
     \begin{itemize}
     \item debugging symbols in both \code{$(STAGING_DIR)} and
       \code{$(TARGET_DIR)}


### PR DESCRIPTION
* Replaced legacy BR2_STRIP_none with BR2_STRIP_strip
  option (as of Buildroot 2017.08-rc1 release).

See https://github.com/buildroot/buildroot/blob/master/Config.in#L432 for latest option notes.
See https://github.com/buildroot/buildroot/blob/master/Config.in.legacy#L3244 for legacy option notes.
See https://github.com/buildroot/buildroot/commit/0d643fd3e8d2e3deb5de936f176286ca2c4f0b62 for commit notes.