### PR TITLE
Typo fixes

### DIFF
--- a/slides/graphics-hardware/graphics-hardware.tex
+++ b/slides/graphics-hardware/graphics-hardware.tex
@@ -229,7 +229,7 @@
     \item One beam for each color with increased intensity for increased luminosity
     \item High energy consumption
     \item High contrast, low response time (\(1-10~\mu s\))
-    \item Other issues: monitor size, burn-in (screensavers), remanent magnetic field (degaussing), high voltages and magnetic fields
+    \item Other issues: monitor size, burn-in (screensavers), remnant magnetic field (degaussing), high voltages and magnetic fields
     \end{itemize}
   \end{itemize}
 
@@ -551,7 +551,7 @@
 
   \begin{itemize}
   \item Very basic VGA encoder from parallel signals, DDC excluded
-  \item Resistor ladder for analog-to-digital conversion\\
+  \item Resistor ladder for digital-to-analog conversion\\
   \textit{using SN74ALVC244 voltage level shifters (\(1.8~V\) to \(3.3~V\)), clamping diodes}
   \item 6 most-significant bits only, 2 least-significant bits set to 0\\
   \textit{D0-D1, D8-D9 and D16-D17 are not routed}

--- a/slides/graphics-software/graphics-software.tex
+++ b/slides/graphics-software/graphics-software.tex
@@ -1351,7 +1351,7 @@ ret = ioctl(drm_fd, DRM_IOCTL_SYNCOBJ_FD_TO_HANDLE, &syncobj_handle);
       \item Turns \code{wl_surfaces} to \code{xdg_surfaces} that can be resized, minimized, etc
       \item Provides a popup/menu interface with \code{xdg_popup}
       \end{itemize}
-    \item \textbf{IVI-Shell}: In-vehicule shell with surface layers
+    \item \textbf{IVI-Shell}: In-vehicle shell with surface layers
     \item \textbf{Presentation time}: Precise timing and event feedback
     \end{itemize}
   \end{itemize}


### PR DESCRIPTION
This PR corrects two misspellings, and I believe that the resistor-ladder digital-to-VGA schematic is for digital-to-analog conversion, not analog-to-digital.