### PR TITLE
kernel: Don't describe / use cscope anymore

### DIFF
--- a/agenda/linux-kernel-agenda.tex
+++ b/agenda/linux-kernel-agenda.tex
@@ -136,8 +136,8 @@
   \item Coding standards
   \item Retrieving Linux kernel sources
   \item Tour of the Linux kernel sources
-  \item Kernel source code browsers: cscope,
-	Elixir Cross Referencer, VS Code...
+  \item Kernel source code browsers:
+        Elixir Cross Referencer, VS Code...
   \end{itemize}
 }
 {Lab - Kernel sources}

--- a/agenda/linux-kernel-fr-agenda.tex
+++ b/agenda/linux-kernel-fr-agenda.tex
@@ -144,7 +144,8 @@
   \item Conventions de codage
   \item Récupération des sources du noyau
   \item Aperçu des sources du noyau
-  \item Outils de navigation dans les sources : cscope, Elixir
+  \item Outils de navigation dans les sources :
+        Elixir Cross Referencer, VS Code...
   \end{itemize}
 }
 {TP - Code source du noyau}

--- a/agenda/linux-kernel-online-agenda.tex
+++ b/agenda/linux-kernel-online-agenda.tex
@@ -141,7 +141,7 @@
   \item Coding standards
   \item Retrieving Linux kernel sources
   \item Tour of the Linux kernel sources
-  \item Kernel source code browsers: cscope,
+  \item Kernel source code browsers:
         Elixir Cross Referencer, VS Code...
   \end{itemize}
 }

--- a/agenda/linux-kernel-online-fr-agenda.tex
+++ b/agenda/linux-kernel-online-fr-agenda.tex
@@ -151,7 +151,8 @@
   \item Conventions de codage
   \item Récupération des sources du noyau
   \item Aperçu des sources du noyau
-  \item Outils de navigation dans les sources : cscope, Elixir
+  \item Outils de navigation dans les sources :
+        Elixir Cross Referencer, VS Code...
   \end{itemize}
 }
 {Démo - Code source du noyau}

--- a/labs/kernel-debugging/kernel-debugging.tex
+++ b/labs/kernel-debugging/kernel-debugging.tex
@@ -111,7 +111,7 @@ code inside the binaries.
 You could disassemble the whole \code{vmlinux} file and work with
 the \code{PC} absolute address, but it is going to take a long time.
 
-Instead, using Elixir or \code{cscope}, you'll find that the crash
+Instead, using Elixir, you'll find that the crash
 happens in an function defined in assembly, called by a function
 implemented in C. Find the \code{.c} source file where
 the C function is implemented.

--- a/labs/kernel-sources-exploring/kernel-sources-exploring.tex
+++ b/labs/kernel-sources-exploring/kernel-sources-exploring.tex
@@ -9,7 +9,7 @@ After this lab, you will be able to:
       stable kernel version (from the \code{stable} kernel tree).
 \item Explore the sources and search for files, function headers or
   other kinds of information\ldots
-\item Browse the kernel sources with tools like \code{cscope} and Elixir.
+\item Browse the kernel sources with tools like \code{VS Code} and Elixir.
 \end{itemize}
 
 \section{Choose a particular stable version}
@@ -73,8 +73,6 @@ automated tools.
 
 Try Elixir at \url{https://elixir.bootlin.com}
 and choose the Linux version closest to yours.
-
-If you don't have Internet access, you can use \code{cscope} instead.
 
 As in the previous section, use this tool to find where
 the \kfunc{platform_device_register} function is declared, implemented and

--- a/slides/kernel-source-code-management/kernel-source-code-management.tex
+++ b/slides/kernel-source-code-management/kernel-source-code-management.tex
@@ -1,36 +1,6 @@
 \subsection{Kernel source management tools}
 
 \begin{frame}
-  \frametitle{Cscope}
-  \begin{itemize}
-  \item Tool to browse source code (mainly C, but also C++ or Java)
-  \item Supports huge projects like the Linux kernel. Typically takes less
-    than 1 min. to index the whole Linux sources.
-  \item In Linux kernel sources, two ways of running it:
-    \begin{itemize}
-    \item \code{cscope -Rk}\\
-      All files for all architectures at once
-    \item \code{make cscope}\\
-      \code{cscope -d cscope.out}\\
-      Only files for your current architecture
-    \end{itemize}
-  \item Allows searching for a symbol, a definition, functions,
-    strings, files, etc.
-  \item Integration with editors like \code{vim} and \code{emacs}.
-  \item \url{http://cscope.sourceforge.net/}
-  \end{itemize}
-\end{frame}
-
-\begin{frame}
-  \frametitle{Cscope screenshot}
-  \begin{center}
-    \includegraphics[height=0.7\textheight]{slides/kernel-source-code-management/cscope.png}
-  \end{center}
-  \code{[Tab]}: move the cursor between search results and commands\\
-  \code{[Ctrl] [D]}: exit \code{cscope}
-\end{frame}
-
-\begin{frame}
   \frametitle{Elixir: browsing the Linux kernel sources}
   \begin{itemize}
   \item \url{https://github.com/bootlin/elixir}


### PR DESCRIPTION
As requested in  https://github.com/bootlin/training-materials/issues/92 the presentation of cscope is removed from the slides and the usage in the lab. 

It is still mentioned in a footnote of the boot-time-kernel lab and together with ctags on the slide about kernel-source-management. 
