### PR TITLE
fix <opts> position on trace-cmd command

### DIFF
--- a/slides/realtime-linux-benchmarking/realtime-linux-benchmarking.tex
+++ b/slides/realtime-linux-benchmarking/realtime-linux-benchmarking.tex
@@ -79,12 +79,12 @@ cat /sys/kernel/tracing/tracing_max_latency
 		\item Wrapper around the \code{ftrace} interface
 		\item Trace only during a program execution :
 			\begin{itemize}
-				\item \code{trace-cmd <opts> record <cmd>}
+				\item \code{trace-cmd record <opts> <cmd>}
 				\item \code{trace-cmd report}
 			\end{itemize}
 		\item Start, stop and show the trace buffer :
 			\begin{itemize}
-				\item \code{trace-cmd <opts> start}
+				\item \code{trace-cmd start <opts>}
 				\item \code{trace-cmd stop}
 				\item \code{trace-cmd show}
 			\end{itemize}


### PR DESCRIPTION
As I could see at the help of `trace-cmd` and the usage, the `<opts>` comes after the `<cmd>`