### PR TITLE
Tinysystem: cpuinfo more portable and better looking

### DIFF
--- a/lab-data/embedded-linux/tinysystem/data/www/cgi-bin/cpuinfo
+++ b/lab-data/embedded-linux/tinysystem/data/www/cgi-bin/cpuinfo
@@ -4,7 +4,7 @@ echo
 echo "<html><header></header><body>"
 echo "<h1>CPU information</h1>"
 echo "Your embedded device uses the below processor:<pre><font color=Blue>"
-echo `cat /proc/cpuinfo | grep Processor`
+echo " "`cat /proc/cpuinfo | grep "model name" | while read cpu; do echo "$cpu <p>"; done`
 echo "</font></pre>"
 echo "<p><a href=\"/index.html\"><img src=\"/gohome.png\" border=\"0\"></a></p>"
 echo "</body></html>"


### PR DESCRIPTION
The cpuinfo cgi-script greps for the 'Processor' string; this does not seem to apply to all architecture (on x86_64 it does not work). Grepping for 'model name' seems to be more portable.

Also, having all CPUs on the same line is a little ugly, with the help of sed we can have a single CPU per line.
It requires to add sed in busybox config.
The initial space added before echoing the result of the pipeline helps in aligning the resulting output.