### PR TITLE
slides: yocto: remove the usage of PRIORITY in recipes

### DIFF
--- a/slides/yocto-recipe-advanced/yocto-recipe-advanced.tex
+++ b/slides/yocto-recipe-advanced/yocto-recipe-advanced.tex
@@ -214,7 +214,6 @@ SRC_URI += "file://defconfig"
     \begin{minted}[fontsize=\scriptsize]{sh}
 DESCRIPTION = "Print a friendly, customizable greeting"
 HOMEPAGE = "https://www.gnu.org/software/hello/"
-PRIORITY = "optional"
 SECTION = "examples"
 LICENSE = "GPL-3.0-or-later"
 
@@ -254,7 +253,6 @@ inherit autotools
   \begin{block}{}
     \begin{minted}[fontsize=\scriptsize]{sh}
 DESCRIPTION = "useradd class usage example"
-PRIORITY = "optional"
 SECTION = "examples"
 LICENSE = "MIT"
 

--- a/slides/yocto-recipe-basics/yocto-recipe-basics.tex
+++ b/slides/yocto-recipe-basics/yocto-recipe-basics.tex
@@ -98,9 +98,9 @@
   \frametitle{The header}
   Configuration variables to describe the application:
   \begin{itemize}
+    \item \yoctovar{SUMMARY}: short descrition for the package manager
     \item \yoctovar{DESCRIPTION}: describes what the software is about
     \item \yoctovar{HOMEPAGE}: URL to the project's homepage
-    \item \yoctovar{PRIORITY}: defaults to \code{optional}
     \item \yoctovar{SECTION}: package category (e.g. \code{console/utils})
     \item \yoctovar{LICENSE}: the application's license, using SPDX identifiers
       (\url{https://spdx.org/licenses/})
@@ -510,9 +510,9 @@ SRC_URI += "file://joystick-support.patch \
   \frametitle{Hello world recipe}
   \begin{block}{}
     \begin{minted}[fontsize=\scriptsize]{sh}
+SUMMARY = "Hello world program"
 DESCRIPTION = "Hello world program"
 HOMEPAGE = "http://example.net/hello/"
-PRIORITY = "optional"
 SECTION = "examples"
 LICENSE = "GPL-2.0-or-later"
 


### PR DESCRIPTION
PRIORITY is not to be used within recipe themselves according to the documentation:

"PRIORITY is considered to be part of the distribution policy because the importance of any given recipe depends on the purpose for which the distribution is being produced. Thus, PRIORITY is not normally set within recipes."

Present SUMMARY as it is widely used in openembedded-core and meta-openemebedded.