### PR TITLE
bitbake getvar

### DIFF
--- a/labs/yocto-advanced-configuration-stm32/yocto-advanced-configuration-stm32.tex
+++ b/labs/yocto-advanced-configuration-stm32/yocto-advanced-configuration-stm32.tex
@@ -90,8 +90,8 @@ packages included into the output image.
 To illustrate this, add the Dropbear SSH server to the list of enabled
 packages.
 
-Tip: do not overwrite the default enabled package list, but append the Dropbear
-package instead.
+Tip: Make sure your modifications are taken into account with
+\code{bitbake-getvar}.
 
 \section{Boot with the updated rootfs}
 

--- a/labs/yocto-advanced-configuration/yocto-advanced-configuration.tex
+++ b/labs/yocto-advanced-configuration/yocto-advanced-configuration.tex
@@ -78,8 +78,8 @@ packages included into the output image.
 To illustrate this, add the Dropbear SSH server to the list of enabled
 packages.
 
-Tip: do not overwrite the default enabled package list, but append the Dropbear
-package instead.
+Tip: Make sure your modifications are taken into account with
+\code{bitbake-getvar}.
 
 \section{Boot with the updated rootfs}
 

--- a/slides/yocto-advanced/yocto-advanced.tex
+++ b/slides/yocto-advanced/yocto-advanced.tex
@@ -218,6 +218,17 @@ IMAGE_INSTALL = "busybox mtd-utils"
   \end{columns}
 \end{frame}
 
+\begin{frame}
+  \frametitle{Debugging variables}
+  \begin{itemize}
+    \item \code{bitbake-getvar} can be used to debug variables.
+    \item Usage: \code{bitbake-getvar [-r RECIPE] variable}
+	\item Since a recipe variable assignation is local, the recipe name must be
+	  specified. If no recipe is specified, only the configuration is taken into
+	  account.
+  \end{itemize}
+\end{frame}
+
 \subsection{Package variants}
 
 \begin{frame}

--- a/slides/yocto-advanced/yocto-advanced.tex
+++ b/slides/yocto-advanced/yocto-advanced.tex
@@ -218,15 +218,32 @@ IMAGE_INSTALL = "busybox mtd-utils"
   \end{columns}
 \end{frame}
 
-\begin{frame}
+\begin{frame}[fragile]
   \frametitle{Debugging variables}
   \begin{itemize}
     \item \code{bitbake-getvar} can be used to debug variables.
     \item Usage: \code{bitbake-getvar [-r RECIPE] variable}
-	\item Since a recipe variable assignation is local, the recipe name must be
-	  specified. If no recipe is specified, only the configuration is taken into
-	  account.
+    \item Since a recipe variable assignation is local, the recipe name must be
+          specified. If no recipe is specified, only the configuration is taken
+          into account.
   \end{itemize}
+  \begin{block}{}
+    \begin{minted}[fontsize=\tiny]{console}
+$ bitbake-getvar -r ninvaders DEPENDS
+# $DEPENDS [4 operations]
+#   set /yocto-labs/poky/meta/conf/bitbake.conf:268
+#     ""
+#   set /yocto-labs/poky/meta/conf/documentation.conf:130
+#     [doc] "Lists a recipe's build-time dependencies (i.e. other recipe files)."
+#   :prepend /yocto-training/yocto-labs/poky/meta/classes/base.bbclass:74
+#     "${BASEDEPENDS} "
+#   set /yocto-labs/meta-bootlinlabs/recipes-games/ninvaders/ninvaders.inc:11
+#     "ncurses"
+# pre-expansion value:
+#   "${BASEDEPENDS} ncurses"
+DEPENDS="virtual/arm-poky-linux-gnueabi-gcc virtual/arm-poky-linux-gnueabi-compilerlibs virtual/libc ncurses"
+    \end{minted}
+  \end{block}
 \end{frame}
 
 \subsection{Package variants}

--- a/slides/yocto-recipe-advanced/yocto-recipe-advanced.tex
+++ b/slides/yocto-recipe-advanced/yocto-recipe-advanced.tex
@@ -361,26 +361,6 @@ do_install() {
     \item For each task, logs are available in the \code{temp}
       directory in the work folder of a recipe. This includes both
       the actual tasks code that ran and the output of the task.
-    \item \code{bitbake} can dump the whole environment, including the
-      variable values and how they were set:
-      \begin{block}{}
-        \begin{minted}[fontsize=\tiny]{console}
-$ bitbake -e ninvaders
-# $DEPENDS [4 operations]
-#   set /yocto-labs/poky/meta/conf/bitbake.conf:268
-#     ""
-#   set /yocto-labs/poky/meta/conf/documentation.conf:130
-#     [doc] "Lists a recipe's build-time dependencies (i.e. other recipe files)."
-#   :prepend /yocto-training/yocto-labs/poky/meta/classes/base.bbclass:74
-#     "${BASEDEPENDS} "
-#   set /yocto-labs/meta-bootlinlabs/recipes-games/ninvaders/ninvaders.inc:11
-#     "ncurses"
-# pre-expansion value:
-#   "${BASEDEPENDS} ncurses"
-DEPENDS="virtual/arm-poky-linux-gnueabi-gcc virtual/arm-poky-linux-gnueabi-compilerlibs virtual/libc ncurses"
-        \end{minted}
-      \end{block}
-
   \end{itemize}
 \end{frame}
 


### PR DESCRIPTION
Hello,

There seems to be a problem with the "Debugging recipes" slide of the yocto-recipe-advanced.tex series of slides. The output of the command looks to be from `bitbake-getvar -r ninvaders DEPENDS` but the command entered is `bitbake -e ninvaders` which prints a different output.

I also found that there is no formal introduction to bitbake-getvar so I added one and moved this snippet of code sooner in the training.

Let me know if this seems OK to you.

Thank you,
Charles