### PR TITLE
Add missing ghostscript dependency

### DIFF
--- a/README
+++ b/README
@@ -10,7 +10,7 @@ python3-pygments texlive-fonts-recommended \
 texlive-fonts-extra make texlive-xetex texlive-extra-utils \
 fonts-inconsolata fonts-liberation \
 xfonts-scalable lmodern texlive-science texlive-plain-generic \
-texlive-lang-french
+texlive-lang-french ghostscript
 
 Then, run 'make help' to see what available targets are.
 


### PR DESCRIPTION
Generating the Embedded Linux training materials according to the instructions in the README leads to a ghostscript error.

This is due to ghostscript not being listed in the dependencies to install using APT.

Solution: add ghostscript to the instructions.