### PR TITLE
remove all occurences of "machine recipes"

### DIFF
--- a/labs/yocto-custom-image/yocto-custom-image.tex
+++ b/labs/yocto-custom-image/yocto-custom-image.tex
@@ -8,8 +8,8 @@ During this lab, you will:
 
 \section{Add a basic image recipe}
 
-A build is configured by two top level recipes: the machine recipe and the image
-one. The image recipe is the top configuration file for the generated rootfs and
+A build is mainly defined by two files: the machine configuration and the image
+recipe. The image recipe is the top level file for the generated rootfs and
 the packages it includes. Our aim in this lab is to define a custom image from
 scratch to allow a precise selection of packages on the target. To
 show how to deal with real world configuration and how the Yocto Project can be

--- a/slides/yocto-image/yocto-image.tex
+++ b/slides/yocto-image/yocto-image.tex
@@ -81,7 +81,7 @@ DESCRIPTION = "Example image"
 IMAGE_INSTALL += "ninvaders"
     \end{minted}
   \end{block}
-  Note: unlike other recipes, machine recipes don't need to set
+  Note: unlike other recipes, image recipes don't need to set
   \yoctovar{LICENSE}.
 \end{frame}
 


### PR DESCRIPTION
Use "machine configuration" instead to avoid being ambiguous.