### PR TITLE
yocto-layers: remove meta-gstreamer10 from the examples

### DIFF
--- a/slides/yocto-layer/yocto-layer.tex
+++ b/slides/yocto-layer/yocto-layer.tex
@@ -110,7 +110,6 @@
       \item \code{meta-browser}: web browsers (Chromium, Firefox).
       \item \code{meta-filesystems}: support for additional
         filesystems.
-      \item \code{meta-gstreamer10}: support for GStreamer 1.0.
       \item \code{meta-java} and \code{meta-oracle-java}: Java support.
       \item \code{meta-linaro-toolchain}: Linaro toolchain recipes.
       \item \code{meta-qt5}: QT5 modules.


### PR DESCRIPTION
GStreamer 1.0 has official support in openembedded-core, meta-gstreamer10 is only used for backports.