### PR TITLE
driver-architecture: bus infrastructure is itself a framework

### DIFF
--- a/slides/kernel-device-model/driver-architecture.dia
+++ b/slides/kernel-device-model/driver-architecture.dia
@@ -2,10 +2,10 @@
 <dia:diagram xmlns:dia="http://www.lysator.liu.se/~alla/dia/">
   <dia:diagramdata>
     <dia:attribute name="background">
-      <dia:color val="#ffffffff"/>
+      <dia:color val="#ffffff"/>
     </dia:attribute>
     <dia:attribute name="pagebreak">
-      <dia:color val="#000099ff"/>
+      <dia:color val="#000099"/>
     </dia:attribute>
     <dia:attribute name="paper">
       <dia:composite type="paper">
@@ -37,9 +37,6 @@
     </dia:attribute>
     <dia:attribute name="grid">
       <dia:composite type="grid">
-        <dia:attribute name="dynamic">
-          <dia:boolean val="true"/>
-        </dia:attribute>
         <dia:attribute name="width_x">
           <dia:real val="1"/>
         </dia:attribute>
@@ -56,7 +53,7 @@
       </dia:composite>
     </dia:attribute>
     <dia:attribute name="color">
-      <dia:color val="#d8e5e5ff"/>
+      <dia:color val="#d8e5e5"/>
     </dia:attribute>
     <dia:attribute name="guides">
       <dia:composite type="guides">
@@ -64,27 +61,8 @@
         <dia:attribute name="vguides"/>
       </dia:composite>
     </dia:attribute>
-    <dia:attribute name="display">
-      <dia:composite type="display">
-        <dia:attribute name="antialiased">
-          <dia:boolean val="false"/>
-        </dia:attribute>
-        <dia:attribute name="snap-to-grid">
-          <dia:boolean val="false"/>
-        </dia:attribute>
-        <dia:attribute name="snap-to-object">
-          <dia:boolean val="true"/>
-        </dia:attribute>
-        <dia:attribute name="show-grid">
-          <dia:boolean val="true"/>
-        </dia:attribute>
-        <dia:attribute name="show-connection-points">
-          <dia:boolean val="true"/>
-        </dia:attribute>
-      </dia:composite>
-    </dia:attribute>
   </dia:diagramdata>
-  <dia:layer name="Arrière-plan" visible="true" connectable="true" active="true">
+  <dia:layer name="Arrière-plan" visible="true" active="true">
     <dia:object type="Standard - Box" version="0" id="O0">
       <dia:attribute name="obj_pos">
         <dia:point val="4.5,14.4"/>
@@ -105,7 +83,7 @@
         <dia:real val="0.20000000298023224"/>
       </dia:attribute>
       <dia:attribute name="border_color">
-        <dia:color val="#cc1f1aff"/>
+        <dia:color val="#cc1f1a"/>
       </dia:attribute>
       <dia:attribute name="show_background">
         <dia:boolean val="true"/>
@@ -131,10 +109,10 @@
         <dia:real val="0.10000000149011612"/>
       </dia:attribute>
       <dia:attribute name="border_color">
-        <dia:color val="#868686ff"/>
+        <dia:color val="#868686"/>
       </dia:attribute>
       <dia:attribute name="inner_color">
-        <dia:color val="#e5e5e5ff"/>
+        <dia:color val="#e5e5e5"/>
       </dia:attribute>
       <dia:attribute name="show_background">
         <dia:boolean val="true"/>
@@ -145,7 +123,7 @@
         <dia:point val="9.5,4"/>
       </dia:attribute>
       <dia:attribute name="obj_bb">
-        <dia:rectangle val="7.99125,3.53;11.0087,4.47"/>
+        <dia:rectangle val="7.99125,3.53184;11.0087,4.46816"/>
       </dia:attribute>
       <dia:attribute name="text">
         <dia:composite type="text">
@@ -159,10 +137,10 @@
             <dia:real val="0.80000000000000004"/>
           </dia:attribute>
           <dia:attribute name="pos">
-            <dia:point val="9.5,4.27"/>
+            <dia:point val="9.5,4.2704"/>
           </dia:attribute>
           <dia:attribute name="color">
-            <dia:color val="#000000ff"/>
+            <dia:color val="#000000"/>
           </dia:attribute>
           <dia:attribute name="alignment">
             <dia:enum val="1"/>
@@ -196,10 +174,10 @@
         <dia:real val="0.10000000149011612"/>
       </dia:attribute>
       <dia:attribute name="border_color">
-        <dia:color val="#a34804ff"/>
+        <dia:color val="#a34804"/>
       </dia:attribute>
       <dia:attribute name="inner_color">
-        <dia:color val="#ffd192ff"/>
+        <dia:color val="#ffd192"/>
       </dia:attribute>
       <dia:attribute name="show_background">
         <dia:boolean val="true"/>
@@ -210,7 +188,7 @@
         <dia:point val="9.5,8"/>
       </dia:attribute>
       <dia:attribute name="obj_bb">
-        <dia:rectangle val="7.92375,7.13;11.0762,8.87"/>
+        <dia:rectangle val="7.92375,7.13184;11.0762,8.86816"/>
       </dia:attribute>
       <dia:attribute name="text">
         <dia:composite type="text">
@@ -225,10 +203,10 @@ Interface#</dia:string>
             <dia:real val="0.80000000000000004"/>
           </dia:attribute>
           <dia:attribute name="pos">
-            <dia:point val="9.5,7.87"/>
+            <dia:point val="9.5,7.8704"/>
           </dia:attribute>
           <dia:attribute name="color">
-            <dia:color val="#000000ff"/>
+            <dia:color val="#000000"/>
           </dia:attribute>
           <dia:attribute name="alignment">
             <dia:enum val="1"/>
@@ -299,10 +277,10 @@ Interface#</dia:string>
         <dia:real val="0.10000000149011612"/>
       </dia:attribute>
       <dia:attribute name="border_color">
-        <dia:color val="#a34804ff"/>
+        <dia:color val="#a34804"/>
       </dia:attribute>
       <dia:attribute name="inner_color">
-        <dia:color val="#ffd192ff"/>
+        <dia:color val="#ffd192"/>
       </dia:attribute>
       <dia:attribute name="show_background">
         <dia:boolean val="true"/>
@@ -313,7 +291,7 @@ Interface#</dia:string>
         <dia:point val="9.5,12"/>
       </dia:attribute>
       <dia:attribute name="obj_bb">
-        <dia:rectangle val="8.03875,11.53;10.9612,12.47"/>
+        <dia:rectangle val="8.04,11.5318;10.96,12.4682"/>
       </dia:attribute>
       <dia:attribute name="text">
         <dia:composite type="text">
@@ -327,10 +305,10 @@ Interface#</dia:string>
             <dia:real val="0.80000000000000004"/>
           </dia:attribute>
           <dia:attribute name="pos">
-            <dia:point val="9.5,12.27"/>
+            <dia:point val="9.5,12.2704"/>
           </dia:attribute>
           <dia:attribute name="color">
-            <dia:color val="#000000ff"/>
+            <dia:color val="#000000"/>
           </dia:attribute>
           <dia:attribute name="alignment">
             <dia:enum val="1"/>
@@ -364,10 +342,10 @@ Interface#</dia:string>
         <dia:real val="0.10000000149011612"/>
       </dia:attribute>
       <dia:attribute name="border_color">
-        <dia:color val="#a34804ff"/>
+        <dia:color val="#a34804"/>
       </dia:attribute>
       <dia:attribute name="inner_color">
-        <dia:color val="#ffd192ff"/>
+        <dia:color val="#ffd192"/>
       </dia:attribute>
       <dia:attribute name="show_background">
         <dia:boolean val="true"/>
@@ -378,7 +356,7 @@ Interface#</dia:string>
         <dia:point val="9.5,16"/>
       </dia:attribute>
       <dia:attribute name="obj_bb">
-        <dia:rectangle val="8.6825,15.53;10.3175,16.47"/>
+        <dia:rectangle val="8.6825,15.5318;10.3175,16.4682"/>
       </dia:attribute>
       <dia:attribute name="text">
         <dia:composite type="text">
@@ -392,10 +370,10 @@ Interface#</dia:string>
             <dia:real val="0.80000000000000004"/>
           </dia:attribute>
           <dia:attribute name="pos">
-            <dia:point val="9.5,16.27"/>
+            <dia:point val="9.5,16.2704"/>
           </dia:attribute>
           <dia:attribute name="color">
-            <dia:color val="#000000ff"/>
+            <dia:color val="#000000"/>
           </dia:attribute>
           <dia:attribute name="alignment">
             <dia:enum val="1"/>
@@ -429,10 +407,10 @@ Interface#</dia:string>
         <dia:real val="0.10000000149011612"/>
       </dia:attribute>
       <dia:attribute name="border_color">
-        <dia:color val="#6a8954ff"/>
+        <dia:color val="#6a8954"/>
       </dia:attribute>
       <dia:attribute name="inner_color">
-        <dia:color val="#c5e387ff"/>
+        <dia:color val="#c5e387"/>
       </dia:attribute>
       <dia:attribute name="show_background">
         <dia:boolean val="true"/>
@@ -443,7 +421,7 @@ Interface#</dia:string>
         <dia:point val="9.5,24"/>
       </dia:attribute>
       <dia:attribute name="obj_bb">
-        <dia:rectangle val="8.24625,23.53;10.7538,24.47"/>
+        <dia:rectangle val="8.24625,23.5318;10.7538,24.4682"/>
       </dia:attribute>
       <dia:attribute name="text">
         <dia:composite type="text">
@@ -457,10 +435,10 @@ Interface#</dia:string>
             <dia:real val="0.80000000000000004"/>
           </dia:attribute>
           <dia:attribute name="pos">
-            <dia:point val="9.5,24.27"/>
+            <dia:point val="9.5,24.2704"/>
           </dia:attribute>
           <dia:attribute name="color">
-            <dia:color val="#000000ff"/>
+            <dia:color val="#000000"/>
           </dia:attribute>
           <dia:attribute name="alignment">
             <dia:enum val="1"/>
@@ -632,7 +610,7 @@ Interface#</dia:string>
         <dia:point val="15,5"/>
       </dia:attribute>
       <dia:attribute name="obj_bb">
-        <dia:rectangle val="15,4.26;17.855,5.2"/>
+        <dia:rectangle val="15,4.26144;17.855,5.19776"/>
       </dia:attribute>
       <dia:attribute name="text">
         <dia:composite type="text">
@@ -649,7 +627,7 @@ Interface#</dia:string>
             <dia:point val="15,5"/>
           </dia:attribute>
           <dia:attribute name="color">
-            <dia:color val="#000000ff"/>
+            <dia:color val="#000000"/>
           </dia:attribute>
           <dia:attribute name="alignment">
             <dia:enum val="0"/>
@@ -665,7 +643,7 @@ Interface#</dia:string>
         <dia:point val="15,14"/>
       </dia:attribute>
       <dia:attribute name="obj_bb">
-        <dia:rectangle val="15,13.53;16.7175,14.47"/>
+        <dia:rectangle val="15,13.5318;16.7175,14.4682"/>
       </dia:attribute>
       <dia:attribute name="text">
         <dia:composite type="text">
@@ -679,10 +657,10 @@ Interface#</dia:string>
             <dia:real val="0.80000000000000004"/>
           </dia:attribute>
           <dia:attribute name="pos">
-            <dia:point val="15,14.27"/>
+            <dia:point val="15,14.2704"/>
           </dia:attribute>
           <dia:attribute name="color">
-            <dia:color val="#000000ff"/>
+            <dia:color val="#000000"/>
           </dia:attribute>
           <dia:attribute name="alignment">
             <dia:enum val="0"/>
@@ -713,10 +691,10 @@ Interface#</dia:string>
         <dia:real val="0.10000000149011612"/>
       </dia:attribute>
       <dia:attribute name="border_color">
-        <dia:color val="#a34804ff"/>
+        <dia:color val="#a34804"/>
       </dia:attribute>
       <dia:attribute name="inner_color">
-        <dia:color val="#ffd192ff"/>
+        <dia:color val="#ffd192"/>
       </dia:attribute>
       <dia:attribute name="show_background">
         <dia:boolean val="true"/>
@@ -764,7 +742,7 @@ Interface#</dia:string>
         <dia:point val="9.5,20"/>
       </dia:attribute>
       <dia:attribute name="obj_bb">
-        <dia:rectangle val="7.1025,19.53;11.8975,20.47"/>
+        <dia:rectangle val="7.1025,19.5318;11.8975,20.4682"/>
       </dia:attribute>
       <dia:attribute name="text">
         <dia:composite type="text">
@@ -778,10 +756,10 @@ Interface#</dia:string>
             <dia:real val="0.80000000000000004"/>
           </dia:attribute>
           <dia:attribute name="pos">
-            <dia:point val="9.5,20.27"/>
+            <dia:point val="9.5,20.2704"/>
           </dia:attribute>
           <dia:attribute name="color">
-            <dia:color val="#000000ff"/>
+            <dia:color val="#000000"/>
           </dia:attribute>
           <dia:attribute name="alignment">
             <dia:enum val="1"/>
@@ -793,6 +771,41 @@ Interface#</dia:string>
       </dia:attribute>
       <dia:connections>
         <dia:connection handle="0" to="O19" connection="8"/>
+      </dia:connections>
+    </dia:object>
+    <dia:object type="Standard - ZigZagLine" version="1" id="O22">
+      <dia:attribute name="obj_pos">
+        <dia:point val="5.94957,20"/>
+      </dia:attribute>
+      <dia:attribute name="obj_bb">
+        <dia:rectangle val="4.84957,11.6382;6.1118,20.05"/>
+      </dia:attribute>
+      <dia:attribute name="orth_points">
+        <dia:point val="5.94957,20"/>
+        <dia:point val="4.89957,20"/>
+        <dia:point val="4.89957,12"/>
+        <dia:point val="6,12"/>
+      </dia:attribute>
+      <dia:attribute name="orth_orient">
+        <dia:enum val="0"/>
+        <dia:enum val="1"/>
+        <dia:enum val="0"/>
+      </dia:attribute>
+      <dia:attribute name="autorouting">
+        <dia:boolean val="true"/>
+      </dia:attribute>
+      <dia:attribute name="end_arrow">
+        <dia:enum val="22"/>
+      </dia:attribute>
+      <dia:attribute name="end_arrow_length">
+        <dia:real val="0.5"/>
+      </dia:attribute>
+      <dia:attribute name="end_arrow_width">
+        <dia:real val="0.5"/>
+      </dia:attribute>
+      <dia:connections>
+        <dia:connection handle="0" to="O19" connection="8"/>
+        <dia:connection handle="1" to="O6" connection="3"/>
       </dia:connections>
     </dia:object>
   </dia:layer>


### PR DESCRIPTION
This is explained much later in the training, but I think it's important to mention this early on already. Otherwise, things that are explained immediately afterwards don't make much sense (e.g. the fact that you have a struct device twice: once for the bus and once for the functional framewoek).

While using the bootlin materials for an internal training, there are a few improvements I made (at least, I consider them improvments myself). Since you probably don't agree with all of them, I'm making separate PRs for each. Feel free to close the PR if you disagree with the idea.