### PR TITLE
kernel-intro-sources: add elixir reference

### DIFF
--- a/slides/kernel-intro-sources/elixir.svg
+++ b/slides/kernel-intro-sources/elixir.svg
@@ -1,0 +1,1 @@
+../sysdev-linux-intro-sources/elixir.svg

--- a/slides/kernel-intro-sources/kernel-intro-sources.tex
+++ b/slides/kernel-intro-sources/kernel-intro-sources.tex
@@ -81,6 +81,35 @@
   \end{itemize}
 \end{frame}
 
+\begin{frame}
+  \frametitle{Going through Linux sources}
+  \begin{columns}
+    \column[t]{0.4\textwidth}
+    \begin{itemize}
+    \item Development tools:
+      \begin{itemize}
+      \item Any text editor will work
+      \item Vim and Emacs support ctags and cscope and therefore can help
+        with symbol lookup and auto-completion.
+      \item It's also possible to use more elaborate IDEs to develop
+        kernel code, like Visual Studio Code.
+      \end{itemize}
+    \end{itemize}
+    \column[t]{0.6\textwidth}
+    \begin{itemize}
+    \item Powerful web browsing: Elixir
+      \begin{itemize}
+      \item Generic source indexing tool and code browser for C and C++.
+      \item Very easy to find symbols declaration/implementation/usage
+      \item Try out \url{https://elixir.bootlin.com}!
+      \end{itemize}
+    \end{itemize}
+    \begin{center}
+      \includegraphics[height=0.5\textheight]{slides/kernel-intro-sources/elixir.pdf}
+    \end{center}
+  \end{columns}
+\end{frame}
+
 \begin{frame}[fragile]
   \frametitle{Need for long term support}
   \begin{itemize}


### PR DESCRIPTION
This reference exists in the embedded system development slides, but not in the kernel training. Elixir is kind of important if you ask me :-)

While using the bootlin materials for an internal training, there are a few improvements I made (at least, I consider them improvments myself). Since you probably don't agree with all of them, I'm making separate PRs for each. Feel free to close the PR if you disagree with the idea.