### PR TITLE
kernel-source-code-drivers: add libgpiod for userspace driver

### DIFF
--- a/slides/kernel-source-code-drivers/kernel-source-code-drivers.tex
+++ b/slides/kernel-source-code-drivers/kernel-source-code-drivers.tex
@@ -245,12 +245,12 @@
 \begin{frame}
   \frametitle{User space device drivers 1/2}
   \begin{itemize}
-  \item The kernel provides certain mechanisms to access hardware
-    directly from userspace:
+  \item The kernel provides some mechanisms to access hardware from userspace:
     \begin{itemize}
     \item USB devices with {\em libusb}, \url{https://libusb.info/}
     \item SPI devices with {\em spidev}, \kdochtml{spi/spidev}
     \item I2C devices with {\em i2cdev}, \kdochtml{i2c/dev-interface}
+    \item GPIOs with {\em libgpiod}, \url{https://libgpiod.readthedocs.io}
     \item Memory-mapped devices with {\em UIO}, including interrupt
       handling, \kdochtml{driver-api/uio-howto}
     \end{itemize}
@@ -264,7 +264,7 @@
   \item Certain classes of devices like printers and scanners do not
     have any kernel support, they have always been handled in user space
     for historical reasons.
-  \item Otherwise this is *not* how the system should be
+  \item Otherwise this is {\bf \em not} how the system should be
     architectured. Kernel drivers should always be preferred!
   \end{itemize}
 \end{frame}


### PR DESCRIPTION
While using the bootlin materials for an internal training, there are a few improvements I made (at least, I consider them improvments myself). Since you probably don't agree with all of them, I'm making separate PRs for each. Feel free to close the PR if you disagree with the idea.