### PR TITLE
labs: sysdev-buildroot: use Linux 6.4 headers

### DIFF
--- a/labs/sysdev-buildroot/sysdev-buildroot.tex
+++ b/labs/sysdev-buildroot/sysdev-buildroot.tex
@@ -156,7 +156,7 @@ button whenever you need more details about a given option:
     }
     (replace \code{<user>} by your actual user name)
   \item \code{External toolchain gcc version}: \code{13.x}
-  \item \code{External toolchain kernel headers series}: \code{6.6.x or later}
+  \item \code{External toolchain kernel headers series}: \code{6.4.x}
   \item \code{External toolchain C library}: \code{musl (experimental)}
   \item We must tell Buildroot about our toolchain configuration, so
     select \code{Toolchain has SSP support?} and


### PR DESCRIPTION
In crosstool-ng 1.26.0, the kernel headers version used can't be higher than Linux 6.4.
Telling Buildroot that the toolchain was built with 6.6 headers will cause it to crash with this error message :
"Incorrect selection of kernel headers: expected 6.6.x, got 6.4.x"