### PR TITLE
Typo in yocto-recipe-basics.tex

### DIFF
--- a/slides/yocto-recipe-basics/yocto-recipe-basics.tex
+++ b/slides/yocto-recipe-basics/yocto-recipe-basics.tex
@@ -597,7 +597,7 @@ SRC_URI[md5sum] = "2cee42a2ff4f1cd4f9298eeeb2264519"
 \begin{frame}
   \frametitle{Log and run files}
   \begin{itemize}
-    \item For each task, these files are generated in the \code{temp}
+    \item For each task, these files are generated in the \code{tmp}
       directory under the recipe work directory
     \item \code{run.do_<taskname>}
       \begin{itemize}


### PR DESCRIPTION
The tmp directory isn't \code{temp}