### PR TITLE
labs: yocto: Untar the correct file to the NFS directory

### DIFF
--- a/labs/yocto-advanced-configuration/yocto-advanced-configuration.tex
+++ b/labs/yocto-advanced-configuration/yocto-advanced-configuration.tex
@@ -88,7 +88,7 @@ accessible by NFS clients. Simply uncompress the archived output image in the
 previously created \code{/nfs} directory:
 \begin{verbatim}
 sudo tar xpf $BUILDDIR/tmp/deploy/images/beaglebone/\
-  core-image-minimal-beaglebone.rootfs.wic.xz -C /nfs
+  core-image-minimal-beaglebone.rootfs.tar.xz -C /nfs
 \end{verbatim}
 
 Then boot the board.


### PR DESCRIPTION
This fixes a small typo in commit f6c905f4a13e15feae904104504a4c3109a421c0.