### PR TITLE
Makefile: fix parallel compilation using inkscape

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,11 +1,13 @@
 # See the README file for usage instructions
 
-INKSCAPE = inkscape
+# SELF_CALL avoids checking other instances, which fails with --jobs > 1.
+# https://gitlab.com/inkscape/inkscape/-/issues/4716#note_1898150983
+INKSCAPE = SELF_CALL=true inkscape
 PDFLATEX = xelatex
 DIA      = dia
 EPSTOPDF = epstopdf
 
-INKSCAPE_IS_NEW = $(shell inkscape --version | grep -q "^Inkscape 1" && echo YES)
+INKSCAPE_IS_NEW = $(shell $(INKSCAPE) --version | grep -q "^Inkscape 1" && echo YES)
 
 ifeq ($(INKSCAPE_IS_NEW),YES)
 INKSCAPE_PDF_OPT = -o


### PR DESCRIPTION
Inkscape does DBus accesses at startup to look for other running instances. The feature fails quite often for some obscure reason. Disable it using (undocumented) SELF_CALL environment variable.

 - [Code doing it in Inkscape](https://gitlab.com/inkscape/inkscape/-/blob/a77b160f/src/inkscape-application.cpp#L557).
 - [They set it for their child extensions](https://gitlab.com/inkscape/inkscape/-/blob/0b4d3151/src/extension/extension.cpp#L529-530).
 - Found in [a bug comment](https://gitlab.com/inkscape/inkscape/-/issues/4716#note_1898150983).

Before:

```
⟩ make clean
⟩ make -j20 full-linux-kernel-slides.pdf
make: *** [Makefile:271: <...PATH-TO-TRAINING-MATERIALS...>/out/./common/sd-card.pdf] Error 134
make: *** Waiting for unfinished jobs....
make: *** [Makefile:271: <...PATH-TO-TRAINING-MATERIALS...>/out/./common/qemu-logo.pdf] Error 134
make: *** [Makefile:269: <...PATH-TO-TRAINING-MATERIALS...>/out/./common/strace-c-output.pdf] Error 134
make: *** [Makefile:269: <...PATH-TO-TRAINING-MATERIALS...>/out/./agenda/qemu-logo.pdf] Error 134
make: *** [Makefile:269: <...PATH-TO-TRAINING-MATERIALS...>/out/./common/gdb-vs-gdbserver.pdf] Error 134
make: *** [Makefile:269: <...PATH-TO-TRAINING-MATERIALS...>/out/./common/logo-cc.pdf] Error 134
⟩ # note that failing targets is random and changes on each call
```

After:

```
⟩ make clean
⟩ make -j20 full-linux-kernel-slides.pdf
⟩ # works without errors
```

---

Posting as a PR as I would appreciate a round of review before pushing to the master branch.