### PR TITLE
github: actions: build in parallel

### DIFF
--- a/.github/actions/build-material-action/build_materials.sh
+++ b/.github/actions/build-material-action/build_materials.sh
@@ -2,4 +2,4 @@
 set -ex
 
 git config --global --add safe.directory $GITHUB_WORKSPACE
-make $*
+make -j$(nproc) $*


### PR DESCRIPTION
According to [GitHub's documentation][0], actions have access to 4 CPUs. Exploit those.

Untested. I tried using [the act project][1] to run GitHub actions locally but got some errors. Let's see what this PR's actions say.

[0]: https://docs.github.com/en/actions/using-github-hosted-runners/using-github-hosted-runners/about-github-hosted-runners#standard-github-hosted-runners-for-public-repositories
[1]: https://github.com/nektos/act