### PR TITLE
labs: kernel-board-setup: fix typo

### DIFF
--- a/labs/kernel-board-setup/kernel-board-setup.tex
+++ b/labs/kernel-board-setup/kernel-board-setup.tex
@@ -117,7 +117,7 @@ the right Bootloader is already there, you just need to reset the
 environment (see below).
 
 If you are doing the labs on your own, please follow instructions 1. and
-2a. from the README available at:
+2.i from the README available at:
 \url{https://github.com/bootlin/training-materials/tree/master/lab-data/common/bootloader/beaglebone-black}
 
 Do not try to use stock/random images from the Internet!


### PR DESCRIPTION
The labs instructions refers a section 2.a from another document whereas it is called 2.i.