### PR TITLE
sysdev: lab: Fix instruction for bbb boot on the sd card

### DIFF
--- a/labs/sysdev-u-boot-bbb/sysdev-u-boot-bbb.tex
+++ b/labs/sysdev-u-boot-bbb/sysdev-u-boot-bbb.tex
@@ -229,8 +229,9 @@ sudo umount /media/$USER/boot/
 
 Insert the SD card in the board slot. To boot the board on the external micro-SD
 card, you need to hold the \code{USER} button close to the USB host
-port, and then power-up or reset the board. You can then release the
-\code{USR} button.
+port, and then power-up the board by unplugging and replugging the power cable.
+You can then release the \code{USER} button. Please beware that a warm reset performed
+with the reset button won't work, as it does not affect the boot source!
 
 This seems like a very inconvenient way of booting the board, but
 the selection of attempting to boot from the external micro-SD card


### PR DESCRIPTION
In the lab for the beagle bone black, the instructions said that to boot on the SD card it was possible to reset the board while holding the `USER` button. This doesn't work, it's necessary to power off the board to boot on the SD card.
Fix the instructions.