### PR TITLE
slides: fix slide selection logic based on training type

### DIFF
--- a/common/printk.tex
+++ b/common/printk.tex
@@ -105,7 +105,7 @@ dev_info(&pdev->dev, "in probe\n");
   \end{itemize}
 \end{frame}
 
-\ifthenelse{\equal{\training}{debugging}}{
+\IfBeginWith{\training}{debugging}{
 \begin{frame}
   \frametitle{pr\_debug() and dev\_dbg() usage}
   \begin{itemize}
@@ -130,7 +130,7 @@ dev_info(&pdev->dev, "in probe\n");
 \end{frame}
 }{}
 
-\ifthenelse{\equal{\training}{linux-kernel}}{
+\IfBeginWith{\training}{linux-kernel}{
 \begin{frame}
   \frametitle{Configuring the priority}
   \begin{itemize}
@@ -158,7 +158,7 @@ dev_info(&pdev->dev, "in probe\n");
 \end{frame}
 }{}
 
-\ifthenelse{\equal{\training}{debugging}}{
+\IfBeginWith{\training}{debugging}{
 \begin{frame}
   \frametitle{Debug logs troubleshooting}
   \begin{itemize}

--- a/common/slide-header.tex
+++ b/common/slide-header.tex
@@ -9,6 +9,7 @@
 \usepackage{tabularx}
 \usepackage{stmaryrd}
 \usepackage{appendixnumberbeamer}
+\usepackage{xstring}
 
 \renewcommand{\thempfootnote}{\arabic{mpfootnote}}
 

--- a/slides/sysdev-kernel-building/sysdev-kernel-building.tex
+++ b/slides/sysdev-kernel-building/sysdev-kernel-building.tex
@@ -465,7 +465,7 @@ CONFIG_FAT_DEFAULT_CODEPAGE=437
       structure as in the sources.
     \item \code{modules.alias}, \code{modules.alias.bin}\\
       Aliases for module loading utilities
-      \ifthenelse{\equal{\training}{linux-kernel}}{, see next slide}{}
+      \IfBeginWith{\training}{linux-kernel}{, see next slide}{}
     \item \code{modules.dep}, \code{modules.dep.bin}\\
         Module dependencies. Kernel modules can depend on other modules,
         based on the symbols (functions and data structures) they use.
@@ -478,7 +478,7 @@ CONFIG_FAT_DEFAULT_CODEPAGE=437
   \end{itemize}
 \end{frame}
 
-\ifthenelse{\equal{\training}{linux-kernel}}{
+\IfBeginWith{\training}{linux-kernel}{
 \begin{frame}{Module alias: {\em modules.alias}}
   \begin{center}
     \includegraphics[width=\textwidth]{slides/kernel-hw-devices/module-alias-usage.pdf}

--- a/slides/sysdev-linux-intro-features/sysdev-linux-intro-features.tex
+++ b/slides/sysdev-linux-intro-features/sysdev-linux-intro-features.tex
@@ -1,4 +1,4 @@
-\ifthenelse{\equal{\training}{linux-kernel}}{
+\IfBeginWith{\training}{linux-kernel}{
   \begin{frame}
   \frametitle{Origin}
   \begin{columns}
@@ -62,9 +62,9 @@
         inter-process communication, process management, memory mapping,
         timers, threads, synchronization primitives, etc.
       \end{itemize}
-      \ifthenelse{\equal{\training}{linux-kernel}}{}{
-      \item This interface is stable over time: only new system calls can
-        be added by the kernel developers
+        \IfBeginWith{\training}{linux-kernel}{
+          \item This interface is stable over time: only new system
+          calls can be added by the kernel developers
       }
     \item This system call interface is wrapped by the C library, and
       user space applications usually never make a system call directly


### PR DESCRIPTION
Previously, when building the slides for the "linux-kernel-beagleplay" training, the generic "linux-kernel" content was not included. This was due to slide selection relying on exact string matching.

To fix this, replaced the equality check with a prefix match using `\IfBeginWith` from the `xstring` package. Now, all trainings starting with "linux-kernel" correctly include the common kernel content.