### PR TITLE
README: Add required packages for ArchLinux

### DIFF
--- a/README
+++ b/README
@@ -12,6 +12,12 @@ fonts-inconsolata fonts-liberation \
 xfonts-scalable lmodern texlive-science texlive-plain-generic \
 texlive-lang-french ghostscript
 
+(example on ArchLinux):
+sudo pacman -S texlive-binextra texlive-fontsextra texlive-fontutils texlive-langfrench \
+  texlive-latex texlive-latexextra texlive-latexrecommended texlive-mathscience \
+  texlive-plaingeneric texlive-xetex git make inkscape python-pygments \
+  ttf-inconsolata ttf-liberation ghostscript otf-latin-modern && yay -S dia-git
+
 Then, run 'make help' to see what available targets are.
 
 For example:


### PR DESCRIPTION
Since I spent a couple of minutes to find the required packages for Arch Linux for a proper generation of `full-networking-slides.pdf` (only tested this), I'm sharing it here.