### PR TITLE
slides/networking: Fix various spelling mistakes

### DIFF
--- a/slides/debugging-system-wide-profiling/debugging-system-wide-profiling.tex
+++ b/slides/debugging-system-wide-profiling/debugging-system-wide-profiling.tex
@@ -1207,7 +1207,7 @@ $ lttng create my-session --set-url=net://remote-system
   \frametitle{eBPF ISA}
   \begin{itemize}
     \item eBPF is a "virtual" ISA, defining its own set of instructions: load
-    and store instruction, arithmetic instructions, jump instructions,etc
+    and store instructions, arithmetic instructions, jump instructions,etc
     \item It also defines a set of 10 64-bits wide registers as well as a
     calling convention:
     \begin{itemize}
@@ -1244,7 +1244,7 @@ $ lttng create my-session --set-url=net://remote-system
       make them "infinite" (e.g: no infinite loop)
       \item a program must make sure that a pointer is valid before
       dereferencing it
-      \item a program can not access arbitrary memory addresses, it must use
+      \item a program cannot access arbitrary memory addresses, it must use
       passed context and available helpers
     \end{itemize}
     \item If a program violates one of the verifier rules, it will be rejected.
@@ -1279,7 +1279,7 @@ $ lttng create my-session --set-url=net://remote-system
     \begin{itemize}
       \item A \code{BPF_PROG_TYPE_TRACEPOINT} program will receive a structure
       containing all data returned to userspace by the targeted tracepoint.
-      \item A \code{BPF_PROG_TYPE_SCHED_CLS} program (used to implement packets
+      \item A \code{BPF_PROG_TYPE_SCHED_CLS} program (used to implement packet
       classifiers) will receive a \kstruct{__sk_buff}, the kernel
       representation of a socket buffer.
       \item You can learn about the context passed to any program type by
@@ -1292,7 +1292,7 @@ $ lttng create my-session --set-url=net://remote-system
   \frametitle{eBPF maps}
   \begin{itemize}
     \item eBPF programs exchange data with userspace or other programs through
-    maps of different nature:
+    maps of different natures:
     \begin{itemize}
       \item \code{BPF_MAP_TYPE_ARRAY}: generic array storage. Can be
       differentiated per CPU
@@ -1419,7 +1419,7 @@ $ profile.py -df -F 99 10 | ./FlameGraph/flamegraph.pl > flamegraph.svg
     \end{minted}
   \end{block}
   \begin{itemize}
-    \item \code{tcpconnect.py} script displays all new TCP connection live
+    \item \code{tcpconnect.py} script displays all new TCP connections live
   \end{itemize}
   \begin{block}{}
     \begin{minted}[fontsize=\footnotesize]{console}
@@ -1494,7 +1494,7 @@ b.attach_kprobe(event=b.get_syscall_fnname("clone"), fn_name="hello")
   \frametitle{libbpf}
   \begin{itemize}
     \item Instead of using a high level framework like BCC, one can use libbpf to
-    build custom tools with a finer control on every aspect of the program.
+    build custom tools with finer control over every aspect of the program.
     \item libbpf is a C-based library that aims to ease eBPF programming thanks
     to the following features:
     \begin{itemize}
@@ -1805,12 +1805,12 @@ $ bpftool gen skeleton trace_sched_switch.bpf.o name trace_sched_switch \
     \begin{itemize}
       \item your kernel must be built with
       \kconfigval{CONFIG_DEBUG_INFO_BTF}{y} to have BTF data embedded. BTF is a
-      format similar to dwarf which encodes data layout and functions
+      format similar to dwarf which encodes data layout and function
       signatures in an efficient way.
       \item your eBPF compiler must be able to emit BTF relocations (both clang
       and GCC are capable of this on recent versions, with the \code{-g} argument)
       \item you need a BPF loader capable of processing BPF programs based on BTF data and
-      adjust accordingly data accesses: \code{libbpf} is the de-facto standard bpf
+      adjust accordingly data access: \code{libbpf} is the de-facto standard bpf
       loader
       \item you then need eBPF APIs to read/write to CO-RE relocatable
       variables. libbpf provides such helpers, like \code{bpf_core_read}
@@ -1832,7 +1832,7 @@ $ bpftool gen skeleton trace_sched_switch.bpf.o name trace_sched_switch \
       been added in version 4.2, and allow to call another program only since
       version 5.10
       \item eBPF spin locks have been added in version 5.1 to prevent
-      concurrent accesses to maps shared between CPUs.
+      concurrent access to maps shared between CPUs.
       \item Different attach types keep being added, but possibly on different
       kernel versions when it depends on the architecture: fentry/fexit attach
       points have been added in kernel 5.5 for x86 but in 6.0 for arm32.
@@ -1848,7 +1848,7 @@ $ bpftool gen skeleton trace_sched_switch.bpf.o name trace_sched_switch \
   \begin{itemize}
     \item eBPF is a very powerful framework to spy on kernel internals: thanks
     to the wide variety of attach point, you can expose almost any kernel code path and data.
-    \item In the mean time, eBPF programs remain isolated from kernel code,
+    \item In the meantime, eBPF programs remain isolated from kernel code,
     which makes it safe (compared to kernel development) and easy to use.
     \item Thanks to the in-kernel interpreter and optimizations like JIT compilation, eBPF is very well
     suited for tracing or profiling with low overhead, even in production

--- a/slides/networking-debugging/networking-debugging.tex
+++ b/slides/networking-debugging/networking-debugging.tex
@@ -46,10 +46,10 @@ retis collect -c skb-drop --stack
 				\item \textit{e.g.} the \textbf{radiotap} headers on 802.11 frames
 			\end{itemize}
 		\item The monitoring happens between the \textbf{driver} and \code{tc}
-		\item On the receive side, it happends before firewalling with netfilter
-		\item Capture format is standardised with the \code{pcap} format
+		\item On the receive side, it happens before firewalling with netfilter
+		\item Capture format is standardized with the \code{pcap} format
 			\begin{itemize}
-				\item frames can be replayed, or analysed on another host
+				\item frames can be replayed, or analyzed on another host
 			\end{itemize}
 	\end{itemize}
 \end{frame}
@@ -74,14 +74,14 @@ retis collect -c skb-drop --stack
 
 \begin{frame}{Traffic generation}
 	\begin{itemize}
-		\item iperf3 : Troughput testing, fairly simple to use
+		\item iperf3 : Throughput testing, fairly simple to use
 		\item netperf : Made by kernel developers, similar to iperf3, more featureful
 		\item scapy : Traffic generator written in python, craft arbitrary frames
 		\item DPDK's \href{https://pktgen-dpdk.readthedocs.io/en/latest/}{pktgen}
 			\begin{itemize}
 				\item PKTgen uses \textbf{kernel bypass}, not supported on every platform
 				\item Allows very fast packet crafting (10gbs)
-				\item Useful to test multi-flow setups, or HW offloading
+				\item Useful for testing multi-flow setups, or HW offloading
 			\end{itemize}
 	\end{itemize}
 \end{frame}
@@ -121,7 +121,7 @@ reply = sr1(packet) 	\end{minted}
 		\item Layer 4 counters : Maintained by the kernel.
 			\begin{itemize}
 				\item \code{netstat -s} or \code{cat /proc/net/netstat}
-				\item More statstics in \code{/proc/net/stat}
+				\item More statistics in \code{/proc/net/stat}
 			\end{itemize}
 		\item Layer 3 counters : Provided by \code{ip -s link show}
 		\item Layer 2 counters : Hardware-provided
@@ -132,7 +132,7 @@ reply = sr1(packet) 	\end{minted}
 
 \begin{frame}{profiling}
 	\begin{itemize}
-		\item Allows identifying the bottlnecks in software
+		\item Allows identifying the bottlenecks in software
 		\item \code{perf} can be used : Rely on hardware and software counters
 		\item \code{Flamegraphs} help identify software bottlenecks, in kernel and userspace
 			\begin{itemize}

--- a/slides/networking-driver-netdev/networking-driver-netdev.tex
+++ b/slides/networking-driver-netdev/networking-driver-netdev.tex
@@ -20,7 +20,7 @@ dev->ethtool_ops = &mvneta_eth_tool_ops;
 	\begin{itemize}
 		\item Most Ethernet controllers today have multiple \textbf{transmit} and \textbf{receive} queues
 		\item \textbf{tx} queues hold \textbf{descriptors} for packets that are yet-to-be-sent
-		\item The NIC will dequeue une packet at a time during transmission, from one of the tx queues
+		\item The NIC will dequeue one packet at a time during transmission, from one of the tx queues
 		\item The TX de-queueing behaviour can sometimes be controlled : Weighted Round-Robin, Per-queue priorities, etc.
 		\item \textbf{rx} queues hold descriptors for packets received that weren't yet handled by the CPU
 		\item the RX buffer size depends on the configured \textbf{MTU}
@@ -48,7 +48,7 @@ void (*ndo_set_rx_mode)(struct net_device *dev);
 			\item \code{dev->uc} contains all the Unicast addresses the interface must accept
 			\item \code{dev->mc} contains all the Multicast addresses the interface must accept
 		\end{itemize}
-	\item The address list in maintained by the Networking stack, updated through \kfunc{dev_uc_add}, \kfunc{dev_uc_del}, \kfunc{dev_mc_add}, etc.
+	\item The address list is maintained by the Networking stack, updated through \kfunc{dev_uc_add}, \kfunc{dev_uc_del}, \kfunc{dev_mc_add}, etc.
 	\end{itemize}
 
 \end{frame}
@@ -146,7 +146,7 @@ int (*set_channels)(struct net_device *, struct ethtool_channels *);
 				\item If the budget is exhausted but there are still packets to process, return \code{budget}
 				\item The polling function may be called with a budget of \code{0}, for TX processing only
 			\end{itemize}
-		\item If the budget isn't exahusted but all packets are processed, call \code{napi_complete_done()} and unmask interrupts
+		\item If the budget isn't exhausted but all packets are processed, call \code{napi_complete_done()} and unmask interrupts
 	\end{enumerate}
 \end{frame}
 
@@ -209,7 +209,7 @@ static int foo_poll(struct napi_struct *napi, int budget)
 		\item During a NAPI poll, drivers are free to acknowledge as many TX packets as they want
 		\item \code{budget} does not apply to TX packets
 			\begin{itemize}
-				\item The NAPI poll function can acknowledge as my TX packets as it wants
+				\item The NAPI poll function can acknowledge as many TX packets as it wants
 			\end{itemize}
 	\end{itemize}
 \end{frame}
@@ -279,7 +279,7 @@ static int foo_poll(struct napi_struct *napi, int budget)
 		\item \textbf{filtering} offloads makes so that the MAC drops unknown MAC addresses and VLANs
 		\item \textbf{classification}-capable controllers may implement more powerful features :
 			\begin{itemize}
-				\item \textbf{header hashing} computes a has of a specific set of fields in the header. Useful for RSS.
+				\item \textbf{header hashing} computes a hash of a specific set of fields in the header. Useful for RSS.
 				\item \textbf{flow steering} allows specific actions (enqueueing, drop, redirection) to be done based on specific header values
 			\end{itemize}
 		\item \textbf{crypto} offload for some tunneling technologies such as MACSec
@@ -338,7 +338,7 @@ static int foo_poll(struct napi_struct *napi, int budget)
 
 \begin{frame}{Flow steering}
 	\begin{itemize}
-		\item Advances controllers have the ability to \textbf{parse} packet headers
+		\item Advanced controllers have the ability to \textbf{parse} packet headers
 		\item This is complex, as the header fields are not at fixed offsets (presence of VLAN tags, encapsulation, etc.)
 		\item This is usually achieved with internal \textbf{TCAM-based lookup engines}
 		\item Traffic is classified based on specific fields : src/dst MAC, src/dst IP, src/dst Port, VLAN, etc.
@@ -359,7 +359,7 @@ static int foo_poll(struct napi_struct *napi, int budget)
 ethtool -K eth0 ntuple on
 ethtool -N eth0 flow-type tcp4 vlan 0xa000 m 0x1fff action 3 loc 1
 			\end{minted}
-		\item Steers Vlan-tagged TCP over IPv3 with priority 6 (\code{0xa000 & 0x1fff}) in queue 3
+		\item Steers Vlan-tagged TCP over IPv4 with priority 6 (\code{0xa000 & 0x1fff}) in queue 3
 		\item Implemented in the \code{.set_rxnfc} ethtool op, \textit{e.g.} \kfunc{mvpp2_ethtool_set_rxnfc}
 		\item Can also be done with \textbf{tc flower}
 			\begin{itemize}
@@ -372,10 +372,10 @@ ethtool -N eth0 flow-type tcp4 vlan 0xa000 m 0x1fff action 3 loc 1
 \begin{frame}{Multi-queue and priorisation}
 	\begin{itemize}
 		\item Some Ethernet Controllers have multiple \code{tx} and\code{rx} queues
-		\item On the \textbf{transmit} side, allows shaping and priorizing traffic
-		\item On the \textbf{receive} side, allows load-balancing and per-queue actions
+		\item On the \textbf{transmit} side, allow shaping and priorizing traffic
+		\item On the \textbf{receive} side, allow load-balancing and per-queue actions
 		\item flows can be assigned to dedicated \textbf{rx queues}
-		\item These queues can in turn be pinned to CPUs, apps, VMs, of be rate-limited.
+		\item These queues can in turn be pinned to CPUs, apps, VMs, or be rate-limited.
 		\item Most of this is controlled through \textbf{tc} in \code{.ndo_setup_tc}
 		\item Example in \kfunc{mvneta_setup_mqprio}
 	\end{itemize}

--- a/slides/networking-driver-overview/networking-driver-overview.tex
+++ b/slides/networking-driver-overview/networking-driver-overview.tex
@@ -100,7 +100,7 @@
 			\includegraphics[width=\textwidth]{slides/networking-driver-overview/net_components_serdes.pdf}
 		\column{0.7\textwidth}
 		\begin{itemize}
-			\item Generic PHY, driving the physical link that come out of the MAC
+			\item Generic PHY, driving the physical link that comes out of the MAC
 			\item Represented by \kstruct{phy}
 			\item Drivers in \kdir{drivers/phy}
 				\begin{itemize}
@@ -150,7 +150,7 @@
 			\includegraphics[width=\textwidth]{slides/networking-driver-overview/net_components_switch.pdf}
 		\column{0.7\textwidth}
 		\begin{itemize}
-			\item DSA Switches are standalone chips, with one more ports connected to the SoC's MAC
+			\item DSA Switches are standalone chips, with one or more ports connected to the SoC's MAC
 				\begin{itemize}
 					\item \textbf{D}istributed \textbf{S}witch \textbf{A}rchitecture
 					\item Relies on \href{https://docs.kernel.org/networking/switchdev.html}{switchdev} for the switching operations
@@ -179,7 +179,7 @@
 			\item Specific to MDIO PHYs, as per the 802.3 specification
 			\item In charge of link management :
 				\begin{itemize}
-					\item Auto-negociation of Speed and Duplex
+					\item Auto-negotiation of Speed and Duplex
 					\item Link detection
 				\end{itemize}
 			\item A generic driver exists using only standard registers

--- a/slides/networking-driver-phy/networking-driver-phy.tex
+++ b/slides/networking-driver-phy/networking-driver-phy.tex
@@ -7,7 +7,7 @@
 		\column{0.65\textwidth}
 		\begin{itemize}
 			\item Ethernet PHYs handle Layer 1 of the OSI model
-			\item Standardised by IEEE 802.3
+			\item Standardized by IEEE 802.3
 			\item \textbf{M}edia \textbf{I}ndependent \textbf{I}nterface
 				\begin{itemize}
 					\item Communication bus between MAC and PHY
@@ -15,7 +15,7 @@
 			\item \textbf{M}edia \textbf{D}ependent \textbf{I}nterface
 				\begin{itemize}
 					\item Communication medium with the \textbf{link partner}
-					\item Can be Cat6 cable, Fibre, Coax, backplane, etc.
+					\item Can be Cat6 cable, Fiber, Coax, backplane, etc.
 				\end{itemize}
 			\item \textbf{M}anagement \textbf{D}ata \textbf{I}nput \textbf{O}utput
 				\begin{itemize}
@@ -25,7 +25,7 @@
 				\end{itemize}
 			\item Optionally, PHYs can raise interrupts
 				\begin{itemize}
-					\item \textit{e.g.} to report link status change
+					\item \textit{e.g.} to report link status changes
 				\end{itemize}
 			\item Optionally, PHYs can have a reset line
 
@@ -112,7 +112,7 @@ int mdiobus_c45_write(struct mii_bus *bus, int addr,  int devad, u32 regnum, u16
 				\item \code{phytool read eth0/1/2} : Read register 2 from mdio device at address 1
 				\item \code{phytool read eth0/1:2/3} : Read register 3 on MMD 2 from mdio device at address 1
 			\end{itemize}
-		\item Can be tedious for indirect accesses
+		\item Can be tedious for indirect access
 		\item \textbf{mdio-tools} uses an out-of-tree module to access MDIO over Netlink
 	\end{itemize}
 \end{frame}
@@ -245,7 +245,7 @@ mdio: mdio@32004 {
 			\end{itemize}
 		\item Managed by the \textbf{phylib} PHY framework
 		\item PHY drivers mostly handle the vendor-specific aspects
-		\item Most of the standardised logic is generic, and implemented in phylib
+		\item Most of the standardized logic is generic, and implemented in phylib
 		\item A \href{https://elixir.bootlin.com/linux/v6.15.1/source/drivers/net/phy/phy_device.c\#L3510}{Generic driver} implements only the standard logic
 			\begin{itemize}
 				\item Used as a fallback when a PHY is detected with no associated driver
@@ -265,7 +265,7 @@ mdio: mdio@32004 {
 				\item \code{phydev.speed} : Established link speed, in Mbps
 				\item \code{phydev.duplex} : Established duplex (half or full)
 			\end{itemize}
-		\item It is in charge of configuring and performing the \textbf{Link negociation}
+		\item It is in charge of configuring and performing the \textbf{Link negotiation}
 			\begin{itemize}
 				\item Based on what the MAC can do and user-specified parameters
 				\item \textit{e.g.} \code{ethtool -s eth0 speed 100 duplex full autoneg on} on a 1G interface
@@ -331,13 +331,13 @@ mdio: mdio@32004 {
 		\item In some scenarios, the mode may change dynamically
 			\begin{itemize}
 				\item For \textbf{serialized} modes that are physically compatible
-				\item Depending on the negociated link speed, the PHY may change its mode
+				\item Depending on the negotiated link speed, the PHY may change its mode
 				\item example: the \href{https://elixir.bootlin.com/linux/v6.15.1/source/drivers/net/phy/marvell10g.c}{Marvell 88x3310 PHY}
-				\item When link speed is negociated at 1Gbps, uses \textbf{SGMII}
-				\item When link speed is negociated at 2.5Gbps, uses \textbf{2500BaseX}
-				\item When link speed is negociated at 10Gbps, uses \textbf{10GBaseR}
+				\item When link speed is negotiated at 1Gbps, uses \textbf{SGMII}
+				\item When link speed is negotiated at 2.5Gbps, uses \textbf{2500BaseX}
+				\item When link speed is negotiated at 10Gbps, uses \textbf{10GBaseR}
 			\end{itemize}
-		\item On the MAC side, may require spefific \textbf{PCS} and \textbf{Serdes} configuration
+		\item On the MAC side, may require specific \textbf{PCS} and \textbf{Serdes} configuration
 	\end{itemize}
 \end{frame}
 
@@ -350,7 +350,7 @@ mdio: mdio@32004 {
 			\end{itemize}
 		\item \code{GMII} : \textbf{G}igabit \textbf{MII} : 8 bits, 10/100/1000Mbps
 			\begin{itemize}
-				\item Rarely found on PCBs, mostly unsed within the SoC
+				\item Rarely found on PCBs, mostly used within the SoC
 			\end{itemize}
 		\item \code{RGMII} : \textbf{R}educed \textbf{G}igabit \textbf{MII} : 4 bits, 10/100/1000Mbps
 			\begin{itemize}
@@ -371,7 +371,7 @@ mdio: mdio@32004 {
 			\begin{itemize}
 				\item \textit{de facto} standard. Lane always clocked at 1.25GHz
 				\item Frames are repeated for 10 and 100Mbps
-				\item Inband signalling : Special word sent on the link to negotiate speed, duplex and flow control
+				\item Inband signaling : Special word sent on the link to negotiate speed, duplex and flow control
 			\end{itemize}
 		\item \code{QSGMII} (Quad SGMII) : Mux 4 different MAC to PHY links on a single 5Gbps lane
 		\item \code{USXGMII} : Standard for 10Gbps link. Supports 10/100/1000Mbps, 2.5/5/10Gbps
@@ -385,7 +385,7 @@ mdio: mdio@32004 {
 
 \begin{frame}{RGMII delay}
 		\begin{itemize}
-			\item RGMII is a popular interface on embedded sytems 
+			\item RGMII is a popular interface on embedded systems
 			\item Per the specification, \textbf{clock} must have a 2ns delay from \textbf{data}
 			\item This is to ensure data signals have settled when sampled
 		\end{itemize}
@@ -424,7 +424,7 @@ mdio: mdio@32004 {
 	\begin{itemize}
 			\item \code{phy-mode} in devicetree : Hardware representation
 				\begin{itemize}
-					\item \textbf{\code{phy-mode = "rgmii";}} : No delays needs to be added
+					\item \textbf{\code{phy-mode = "rgmii";}} : No delays need to be added
 					\item \textbf{\code{phy-mode = "rgmii-id";}} : delays need to be added internally
 					\item \textbf{\code{phy-mode = "rgmii-txid";}} : delays need to be added in TX
 					\item \textbf{\code{phy-mode = "rgmii-rxid";}} : delays need to be added in RX
@@ -498,7 +498,7 @@ mdio: mdio@32004 {
 
 \begin{frame}{Interactions between MAC and PHY drivers}
 	\begin{itemize}
-		\item \textbf{phylib} provides an simple API for PHY consumers
+		\item \textbf{phylib} provides a simple API for PHY consumers
 			\begin{itemize}
 				\item \kfunc{phy_start}, \kfunc{phy_stop}, \kfunc{phy_connect}
 				\item \kfunc{phy_suspend}, \kfunc{phy_resume} for power management
@@ -583,7 +583,7 @@ __set_bit(PHY_INTERFACE_MODE_2500BASEX, phylink_config.supported_interfaces);
 	\begin{itemize}
 		\item \textbf{S}mall \textbf{F}ormfactor \textbf{P}luggable is defined by the SFF standards
 		\item It allows having a hot-pluggable \textbf{module} that deals with the Media side
-		\item Useful for \textbf{Fibre} links, but also exists in Copper flavours (BaseT or DAC)
+		\item Useful for \textbf{Fiber} links, but also exists in Copper flavours (BaseT or DAC)
 		\item Each module has a standardized behaviour and interface :
 			\begin{itemize}
 				\item An \textbf{i2c} bus and some GPIOs are used to control the module
@@ -629,7 +629,7 @@ __set_bit(PHY_INTERFACE_MODE_2500BASEX, phylink_config.supported_interfaces);
 				\item When an SFP module is driven by a PHY, and contains a PHY itself
 				\item When a PHY is used as a \textbf{media converter}
 			\end{itemize}
-		\item Netlink requests targetting PHY devices can now be passed a \textbf{phy index}
+		\item Netlink requests targeting PHY devices can now be passed a \textbf{phy index}
 			\begin{itemize}
 				\item Implemented by \kfile{drivers/net/phy/phy_link_topology.c}
 			\end{itemize}

--- a/slides/networking-driver-switch/networking-driver-switch.tex
+++ b/slides/networking-driver-switch/networking-driver-switch.tex
@@ -13,11 +13,11 @@
 \begin{frame}{Ethernet switches in Linux}
 	\begin{itemize}
 		\item By default, without any further configuration, each port is \textbf{independent}
-		\item As each port has their \code{net_device}, they have a their own \code{net_device_ops}
+		\item As each port has their \code{net_device}, they have their own \code{net_device_ops}
 		\item Non-DSA switches are just regular Ethernet drivers, with extra logic for switchdev
 		\item DSA switches have their ports handled by the \href{https://elixir.bootlin.com/linux/v6.15.2/source/net/dsa/port.c}{DSA port} infrastructure
 			\begin{itemize}
-				\item Implemts the \code{.ndo_start_xmit}
+				\item Implements the \code{.ndo_start_xmit}
 			\end{itemize}
 	\end{itemize}
 \end{frame}
@@ -95,7 +95,7 @@ static int adin1110_setup_notifiers(void)
 				\item \code{SWITCHDEV_OBJ_ID_PORT_VLAN} : A port belongs to a VLAN
 				\item \code{SWITCHDEV_OBJ_ID_PORT_MDB} : Add a Multicast address to a port
 			\end{itemize}
-		\item Drivers notify the kernel when the operation was able to be offloaded
+		\item Drivers notify the kernel when the operation could be offloaded
 			\begin{itemize}
 				\item \textit{e.g.} \code{call_switchdev_notifiers(SWITCHDEV_FDB_OFFLOADED, ndev, &info.info, NULL);}
 			\end{itemize}
@@ -131,7 +131,7 @@ static int adin1110_setup_notifiers(void)
 		\item A vendor-specific TAG is added to the frame
 		\item It contains the identifier of the egress port
 		\item The frame is sent from the CPU to the switch
-		\item The switch strips the tag and sends it on the port
+		\item The switch strips the tag and sends it to the port
 		\item The opposite happens on receive
 	\end{itemize}
 	\end{columns}
@@ -246,7 +246,7 @@ static const struct dsa_device_ops foo_ops = {
 \begin{frame}{Chaining}
 	\begin{itemize}
 		\item Some DSA switches can be daisy-chained
-		\item The ports that link switches together don't have associated \code{net_device}
+		\item The ports that link switches together have no associated \code{net_device}
 	\end{itemize}
 	\includegraphics[width=\textwidth]{slides/networking-driver-switch/chained.pdf}
 \end{frame}

--- a/slides/networking-filtering/networking-filtering.tex
+++ b/slides/networking-filtering/networking-filtering.tex
@@ -38,7 +38,7 @@
 \begin{frame}{nftables}
 	\begin{itemize}
 		\item Originates from the \href{https://www.netfilter.org/}{Netfilter project}
-		\item More modern approach, with a centralised filtering table and multiple \textbf{hooks}
+		\item More modern approach, with a centralized filtering table and multiple \textbf{hooks}
 		\item Rules expressed in a low-level language
 		\item Users attach \textbf{chains} to \textbf{hooks} to express rules
 		\item Chains are stored within \textbf{tables} created by users

--- a/slides/networking-skb/networking-skb.tex
+++ b/slides/networking-skb/networking-skb.tex
@@ -18,7 +18,7 @@
 		\item Also contains a lot of specific flags :
 			\begin{itemize}
 				\item \code{wifi_acked} : Was the packet ack'd, wifi-specific
-				\item \code{decrypted} : Does the packet needs decryption ?
+				\item \code{decrypted} : Does the packet need decryption ?
 				\item \code{redirected} : Was the skb redirected ?
 			\end{itemize}
 	\end{itemize}
@@ -76,7 +76,7 @@
 		\end{column}
 		\begin{column}{0.7\textwidth}
 			\begin{itemize}
-				\item Buffers bigger than the \textbf{MTU} needs to be fragmented
+				\item Buffer bigger than the \textbf{MTU} needs to be fragmented
 				\item The original \code{skb} gets split into multiple parts
 				\item Each fragment is its \textbf{own skb}
 				\item Fragments are chained together through :
@@ -223,11 +223,11 @@
 	\begin{itemize}
 		\item \textbf{p}otentially fragmented \textbf{skb} helpers manipulate non-linear \code{skb}
 		\item Useful if you don't know and don't mind if the \code{skb} is paged
-		\item Not all helper have a matching \code{pskb} equivalent, not always relevant
+		\item Not all helpers have a matching \code{pskb} equivalent, not always relevant
 		\item \kfunc{skb_put} => \kfunc{pskb_put}
 		\item \kfunc{skb_pull} => \kfunc{pskb_pull}
 		\item \kfunc{skb_trim} => \kfunc{pskb_trim}
-		\item \kfunc{pskb_may_pull} indicates if a \code{pskb_pull} operation will succedd
+		\item \kfunc{pskb_may_pull} indicates if a \code{pskb_pull} operation will succeed
 			\begin{itemize}
 				\item \kfunc{pskb_may_pull_reason} returns a \textbf{drop reason} if it will fail
 			\end{itemize}
@@ -240,7 +240,7 @@
 		\item A new linear \code{skb} is allocated with \kfunc{alloc_skb}. It also allocates its data buffer.
 		\item A paged \code{skb} can be allocated with \kfunc{alloc_skb_with_frags}
 		\item A newly-allocated \code{skb} is empty : \code{skb->data} == \code{skb->head} == \code{skb->tail}
-		\item \kfunc{skb_reserve} grows the headroom, then \kfunc{skb_push} to prepares the data section
+		\item \kfunc{skb_reserve} grows the headroom, then \kfunc{skb_push} to prepare the data section
 	\end{itemize}
 	\includegraphics[width=\textwidth]{slides/networking-skb/newskb.pdf}
 \end{frame}
@@ -274,7 +274,7 @@ void kfree_skb_reason(struct sk_buff *skb, enum skb_drop_reason reason);
 		\column{0.7\textwidth}
 		\begin{itemize}
 			\item When \textbf{ingress} packets traverse the stack, they are decapsulated
-			\item Each header usually have a field indicating the nature of the upper layer
+			\item Each header usually has a field indicating the nature of the upper layer
 				\begin{itemize}
 					\item Ethernet header : \code{Ethertype} (2 bytes)
 					\item IPv4 header : \code{Protocol} (1 byte)
@@ -505,7 +505,7 @@ int inet6_add_offload(const struct net_offload *prot, unsigned char num);
 		\item Allows a slow-path and fast-path for routing and bridging
 		\item The first packet of a given flow goes through the whole stack
 		\item The final routing or bridging decision is cached
-		\item The next packet from the same flow will go through the fastpath
+		\item The next packet from the same flow will go through the fast-path
 		\item These decisions may be offloaded to hardware
 	\end{itemize}
 \end{frame}

--- a/slides/networking-socket/networking-socket.tex
+++ b/slides/networking-socket/networking-socket.tex
@@ -27,14 +27,14 @@ int socket(int domain, int type, int protocol);
 	\center{\code{int socket(}{\color{orange}int domain}\code{, int type, int protocol);}}
 	\vspace{1cm}
 	\begin{itemize}
-		\item Familes as defined by \textbf{UNIX}, \textbf{POSIX} or are \textbf{Linux}-specific
+		\item Families as defined by \textbf{UNIX}, \textbf{POSIX} or are \textbf{Linux}-specific
 		\item In Linux, defined in \code{include/linux/socket.h}
 			\begin{itemize}
 				\item \code{AF_UNIX}, \code{AF_LOCAL} : Unix Domain Sockets, for IPC. See \manpage{unix}{7}
 				\item \code{AF_INET}, \code{AF_INET6} : IPv4 and IPv6 sockets, see \manpage{ip}{7}
 				\item \code{AF_PACKET} (\textit{raw} sockets) : Layer 2 sockets, see \manpage{packet}{7}
 				\item \code{AF_NETLINK}, \code{AF_ROUTE} : Userspace to kernel sockets for configuration, see \manpage{netlink}{7}
-				\item More specialised families : \code{AF_BLUETOOTH}, \code{AF_IEE802154}, \code{AF_NFC}, etc.
+				\item More specialized families : \code{AF_BLUETOOTH}, \code{AF_IEE802154}, \code{AF_NFC}, etc.
 			\end{itemize}
 		\item Socket families are named \code{AF_xxx}, but equivalent names \code{PF_xxx} also exist
 			\begin{itemize}
@@ -47,7 +47,7 @@ int socket(int domain, int type, int protocol);
 \begin{frame}{Socket Types}
 	\center{\code{int socket(int domain, }{\color{orange}int type}\code{, int protocol);}}
 	\begin{itemize}
-		\item Socket types indicates the transmission semantics, which usually means Layer 4
+		\item Socket type indicates the transmission semantics, which usually means Layer 4
 		\item Its meaning depends on the selected \textbf{domain} :
 			\begin{itemize}
 				\item \code{socket(AF_INET, SOCK_DGRAM, 0)} : UDP over IPv4 socket
@@ -132,7 +132,7 @@ struct sockaddr_in {
 \code{int connect(int sockfd, const struct sockaddr *addr, socklen_t addrlen)}
 	\begin{itemize}
 		\item Connect to a remote listening socket, \manpage{connect}{2}
-		\item For connection-less protcols, it simply sets the destination address for datagrams
+		\item For connection-less protocols, it simply sets the destination address for datagrams
 	\end{itemize}
 \end{frame}
 
@@ -163,7 +163,7 @@ struct sockaddr_in {
 \begin{frame}{Socket queues}
 	\begin{itemize}
 		\item All sockets are created with 2 queues : A \textbf{Receive} queue and a \textbf{Transmit} queue
-		\item Queues size is the same for every socket at creation time, but can be adjusted
+		\item Queue size is the same for every socket at creation time, but can be adjusted
 			\begin{itemize}
 				\item With the \code{SO_RCVBUF} socket option, see \manpage{socket}{7}
 				\item Using the \code{net.core.rmem_default} sysctl
@@ -239,8 +239,8 @@ struct sockaddr_in {
 
 \begin{frame}{sendmsg() and recvmsg()}
 	\begin{itemize}
-		\item Allows passing ancilliary data alongside the buffers
-		\item Ancilliary data is following the \code{cmsg} format
+		\item Allows passing ancillary data alongside the buffers
+		\item Ancillary data is following the \code{cmsg} format
 		\item Also allows scatter-gather buffers
 	\end{itemize}
 \code{ssize_t recvmsg(int sockfd, struct msghdr *msg, int flags)}
@@ -256,7 +256,7 @@ struct sockaddr_in {
 \code{ssize_t sendmsg(int sockfd, const struct msghdr *msg, int flags)}
 	\begin{itemize}
 		\item Sends single or scatter-gather buffers to a designed peer
-		\item Also accepts ancilliary data
+		\item Also accepts ancillary data
 	\end{itemize}
 
 \end{frame}
@@ -326,18 +326,18 @@ struct sockaddr_in {
 
 \begin{frame}{Timestamping}
 	\begin{itemize}
-		\item Timestamping traffic is useful for \textbf{debugging} and \textbf{time synchronisation} (PTP)
+		\item Timestamping traffic is useful for \textbf{debugging} and \textbf{time synchronization} (PTP)
 		\item The \code{SO_TIMESTAMP} \textbf{sockopt} causes timestamp creation for \textbf{ingress datagrams}
 		\item The newer \code{SO_TIMESTAMPING} allows configuring the timestamp source :
 			\begin{itemize}
 				\item Hardware timestamp generation (configurable through \code{ethtool})
 				\item Software timestamp generation, in the driver
 				\item TX sched timestamping, can help measure the queueing delay
-				\item TX ACK for TCP, when the acknowledgement was received
+				\item TX ACK for TCP, when the acknowledgment was received
 				\item TX completion timestamping, when the packet finished being sent
 			\end{itemize}
 		\item Timestamping can also be configured \textbf{per-packet} with \code{sendmsg()} and \code{recvmsg()}
-		\item Timestamps are received through \code{recvmsg} ancilliary data in RX
+		\item Timestamps are received through \code{recvmsg} ancillary data in RX
 		\item \textbf{TX timestamps} are accessible through the socket's \textbf{error queue}
 			\begin{itemize}
 				\item Packets are looped-back through the error queue with an associated timestamp
@@ -349,7 +349,7 @@ struct sockaddr_in {
 	\begin{itemize}
 		\item \code{io_uring} is an alternative to \textbf{socket} programming
 		\item It is an asynchronous API, originally developed for the Storage subsystem
-		\item Aims at reducing the amount of \code{syscalls} such as \code{read} and \code{write}
+		\item Aims at reducing the number of \code{syscalls} such as \code{read} and \code{write}
 		\item Recently, \code{io_uring} gained network support
 			\begin{itemize}
 				\item Applications have to create special ring-buffers shared with the kernel

--- a/slides/networking-stack-control/networking-stack-control.tex
+++ b/slides/networking-stack-control/networking-stack-control.tex
@@ -76,8 +76,8 @@ fd = socket(AF_NETLINK, SOCK_RAW, NETLINK_GENERIC);
 			\end{minted}
 		\item Allows easy extension of the userspace API without breaking compatibility
 		\item User applications must open a \textbf{netlink socket} and send specially-formatted messages
-		\item The socket can also be listened to for Kernel to userspace notificatins
-		\item Netlink messages are grouped in \textbf{families}, grouping message types per class.
+		\item The socket can also be listened to for Kernel to userspace notifications
+		\item Netlink messages are grouped into \textbf{families}, grouping message types per class.
 			\begin{itemize}
 				\item routing, ethtool, 802.11, team, macsec, etc. 
 			\end{itemize}
@@ -88,8 +88,8 @@ fd = socket(AF_NETLINK, SOCK_RAW, NETLINK_GENERIC);
 \begin{frame}{Netlink Classic vs Netlink Generic}
 	\begin{itemize}
 		\item Most netlink users today use \textbf{generic netlink}
-		\item This replaces \textbf{classic netlink}, which has statically allocated familiy ID
-		\item Generic Netlink (\code{genetlink}) allows dynamic family regstration 
+		\item This replaces \textbf{classic netlink}, which has statically allocated family ID
+		\item Generic Netlink (\code{genetlink}) allows dynamic family registration
 			\begin{itemize}
 				\item Allows easy implementation of custom families
 				\item Families are looked-up by \textbf{name} (a string) instead of ID.
@@ -182,7 +182,7 @@ operations:
 				\item Included by \kfile{include/uapi/linux/ethtool_netlink.h}
 			\end{itemize}
 		\item When modifying the specs, headers can be regenerated with \code{${KDIR}/tools/net/ynl/ynl-regen.sh}
-		\item The \textbf{ynl} tool included in the kernel's sources can be used to sent hand-crafted messages
+		\item The \textbf{ynl} tool included in the kernel's sources can be used to send hand-crafted messages
 			\begin{itemize}
 				\item \code{make -C tools/net/ynl}
 			\end{itemize}
@@ -194,7 +194,7 @@ operations:
 
 \begin{frame}{Netlink monitor}
 	\begin{itemize}
-		\item \textbf{Netlink Monitoring} car refer to 2 distinct operations :
+		\item \textbf{Netlink Monitoring} can refer to 2 distinct operations :
 		\item One can listen to \textbf{netlink notifications}
 			\begin{itemize}
 				\item Emitted by the kernel upon configuration change
@@ -229,7 +229,7 @@ operations:
 				\item Very recent feature, introduced in \code{v6.14}
 			\end{itemize}
 		\item The list of \kstruct{net_device} is protected by RCU
-		\item All \kstruct{net_device} instance are reference-counted and reference-tracked
+		\item All \kstruct{net_device} instances are reference-counted and reference-tracked
 	\end{itemize}
 \end{frame}
 
@@ -288,7 +288,7 @@ const struct nla_policy ethnl_linkmodes_set_policy[] = {
 		\item Helpers are provided to get attribute values, \textit{e.g.} \kfunc{nla_get_u32}
 		\begin{minted}{c}
 if (data[IFLA_MACSEC_WINDOW])
-        secy->replay_window = nla_get_u32(data[IFLA_MACSEC_WINDOW]);	
+        secy->replay_window = nla_get_u32(data[IFLA_MACSEC_WINDOW]);
 		\end{minted}
 	\end{itemize}
 \end{frame}
@@ -334,7 +334,7 @@ int dsa_port_mst_enable(struct dsa_port *dp, bool on, struct netlink_ext_ack *ex
 				\item \code{ip} : Configure and query interfaces, routing and tunnels
 				\item \code{bridge} : Configures bridges (switching)
 				\item \code{tc} : Configures traffic control policing, shaping and filtering
-				\item \code{dcb} : Configures "Data Center Bridging" for traffic priorisation
+				\item \code{dcb} : Configures "Data Center Bridging" for traffic prioritization
 				\item These tools use the \textbf{Netlink} API
 			\end{itemize}
 		\item \textbf{net-tools}
@@ -377,7 +377,7 @@ int dsa_port_mst_enable(struct dsa_port *dp, bool on, struct netlink_ext_ack *ex
 
 \begin{frame}{C library}
 	\begin{itemize}
-		\item The C library exposes a few helper functions to manipulate Network features
+		\item The "Standard" C library exposes a few helper functions to manipulate Network features
 		\item \code{if_nametoindex}: Get the \code{ifindex} of a given interface
 		\item \code{if_indextoname}: Get the name of an interface from its \code{index}
 			\begin{itemize}

--- a/slides/networking-stack-netdevice/networking-stack-netdevice.tex
+++ b/slides/networking-stack-netdevice/networking-stack-netdevice.tex
@@ -21,10 +21,10 @@
 		\item The \kstruct{net_device} structure represents a conduit
 		\item Used for \textbf{physical} interfaces and \textbf{virtual} interfaces
 		\item Abstract interfaces can be used for \textbf{vlan}, \textbf{bridging}, \textbf{tap}, \textbf{veth}, etc.
-		\item Every \kstruct{net_device} objects can transmit and receive packets :
+		\item Every \kstruct{net_device} object can transmit and receive packets :
 			\begin{itemize}
 				\item Physically, in which case it is managed by a device driver
-				\item or Logically, by passing them to another component in the stack after potientally altering them
+				\item or Logically, by passing them to another component in the stack after potentially altering them
 			\end{itemize}
 		\item Instances of \kstruct{net_device} are often called \code{netdev} in the Documentation
 		\item Variables of that type are usually named \code{dev}

--- a/slides/networking-stack-overview/networking-stack-overview.tex
+++ b/slides/networking-stack-overview/networking-stack-overview.tex
@@ -11,8 +11,8 @@
 		\item Defines 7 \textbf{layers}, with specific functions and semantics
 		\item Each layer relies on the layer below, and provides features to the layer above
 			\begin{itemize}
-				\item In practise, this is done through \textbf{encapsulation}
-				\item Each layer add its required data at the front of the data array
+				\item In practice, this is done through \textbf{encapsulation}
+				\item Each layer adds its required data to the front of the data array
 					\begin{itemize}
 						\item This is the layer's \textbf{header}
 					\end{itemize}
@@ -85,7 +85,7 @@
 		\item Point-to-point \textbf{frames} are sent on the medium, separated by a \textbf{gap}
 		\item Regardless of the speed and medium, frames have the same structure :
 			\begin{itemize}
-				\item 7 bytes \textbf{Preamble}: Used to synchronize both equipments
+				\item 7 bytes \textbf{Preamble}: Used to synchronize both equipment
 				\item 1 byte \textbf{SFD} (Start Frame Delimiter): Ends the preamble
 				\item 6 bytes \textbf{Destination address}, identifying the destination equipment
 				\item 6 bytes \textbf{Source address}, identifying the source equipment
@@ -109,7 +109,7 @@
 			\end{itemize}
 		\item Ethernet switches are usually \textbf{transparent switches}
 			\begin{itemize}
-				\item They monitor Layer 2 header to \textbf{learn} the Port to Address assciation
+				\item They monitor Layer 2 header to \textbf{learn} the Port to Address association
 				\item This is stored in the FDB : \textbf{F}orwarding \textbf{D}ata\textbf{B}ase
 			\end{itemize}
 		\item Some switches can be highly configurable, and support \text{VLAN}s
@@ -150,7 +150,7 @@
 				\item MACVlan : Based only on MAC addresses
 			\end{itemize}
 		\item Logical segmentation of the network
-		\item Used for isolation, priorisation and bandwitdh optimisation
+		\item Used for isolation, prioritization and bandwidth optimization
 		\item The same conduit can be used to convey multiple VLANs
 			\begin{itemize}
 				\item We talk about a \textbf{trunk} interface
@@ -164,7 +164,7 @@
 	\includegraphics[width=0.8\textwidth]{slides/networking-stack-overview/ethernet_frame_vlan.pdf}
 
 	\begin{itemize}
-		\item A 802.1Q frame has includes an extra \textbf{4 bytes} tag in the Ethernet header
+		\item A 802.1Q frame has included an extra \textbf{4 bytes} tag in the Ethernet header
 		\item The \textbf{ethertype} is set to \code{0x8100}, the real ethertype is stored after the tag
 		\item A 16 bits value identifies the Tag : \textbf{T}ag \textbf{C}ontrol \textbf{I}nformation
 			\begin{itemize}
@@ -175,7 +175,7 @@
 				\item 1 bit \textbf{D}rop \textbf{E}ligible \textbf{I}ndicator
 				\item 12 bits represent the ID of the vlan, between 1 and 4094
 					\begin{itemize}
-						\item ID 0 means \textbf{no tag}, only the priority is consided
+						\item ID 0 means \textbf{no tag}, only the priority is considered
 						\item ID \textbf{4095} is reserved.
 					\end{itemize}
 			\end{itemize}
@@ -211,19 +211,19 @@
 	\begin{itemize}
 		\item Communication between endpoints over a routed network
 			\begin{itemize}
-				\item \textit{e.g.} Multple applications on the same machine
+				\item \textit{e.g.} Multiple applications on the same machine
 				\item Each end-point is further identified within the host 
 				\item on TCP and UDP, \textbf{ports} are used
 			\end{itemize}
 		\item TCP : Connection-oriented, reliable, guarantees ordering.
 			\begin{itemize}
-				\item Stream of data, boundaries may be be preserved 
+				\item Stream of data, boundaries may be preserved
 			\end{itemize}
 		\item UDP : Connection-less, not reliable, no ordering guarantee
 			\begin{itemize}
 				\item Sends datagrams with clear boundaries
 			\end{itemize}
-		\item QUIC : Based on UDP, introduced by Google. Connection-oriended, reliable, guarantees ordering
+		\item QUIC : Based on UDP, introduced by Google. Connection-oriented, reliable, guarantees ordering
 			\begin{itemize}
 				\item Can batch Acknowledgments, supports encryption (i think)
 			\end{itemize}
@@ -239,7 +239,7 @@
 	\column{0.7\textwidth}
 	\begin{itemize}
 		\item Encapsulate a Lower-level layer into a higher one
-		\item Used to virtualise networks (e.g. VXLAN is Ethernet over UDP)
+		\item Used to virtualize networks (e.g. VXLAN is Ethernet over UDP)
 		\item Also used for encryption (IPSec, Wireguard, OpenVPN)
 			\begin{itemize}
 				\item \textit{e.g.} Wireguard Encrypts and encapsulates IP packets into UDP packets
@@ -255,7 +255,7 @@
 			\begin{itemize}
 				\item \textit{e.g.} RPC, SOCKS
 			\end{itemize}
-		\item Presentation : Handles the data conversion and serialization for interoperability
+		\item Presentation : Handles data conversion and serialization for interoperability
 			\begin{itemize}
 				\item \textit{e.g.} character transcoding depending on the locale
 				\item \textit{e.g.} serializing user data in \code{JSON} or \code{XML}
@@ -360,7 +360,7 @@
 				\item Vlan with 802.1Q and 802.1AD
 				\item Bridging and Switching
 				\item MACSec (802.1ae) for Ethernet-level encryption
-				\item Teaming, Bonding, HSR and PRP for link redudancy
+				\item Teaming, Bonding, HSR and PRP for link redundancy
 			\end{itemize}
 		\item Raw Ethernet frames can be sent and received in userspace API with \code{AF_PACKET}
 	\end{itemize}
@@ -418,7 +418,7 @@
 \begin{frame}{Userspace Networking}
 	\begin{itemize}
 		\item Userspace applications can also access traffic at various points in the stack through sockets :
-		\item \code{AF_PACKET} Sockets allows raw Layer 2 access
+		\item \code{AF_PACKET} Sockets allow raw Layer 2 access
 			 \begin{itemize}
 				 \item Can be used for custom protocol support in userspace
 				 \item Used by \code{libpcap} and traffic monitoring tools like \textbf{tcpdump} and \textbf{wireshark}
@@ -426,7 +426,7 @@
 		 \item \code{socket(AF_PACKET, SOCK_DGRAM, 0)} sockets expose raw IPv4 and IPv6 packets
 		\item Some protocols only have userspace implementations by design :
 			\begin{itemize}
-				\item QUIC : Not in the kernel when the protocol was first intrduced
+				\item QUIC : Not in the kernel when the protocol was first introduced
 					\begin{itemize}
 						\item Rationale was to prevent ossification
 						\item Recent kernel-side implementation submitted for inclusion in the kernel
@@ -444,7 +444,7 @@
 		\item Contrary to \code{AF_PACKET}, Kernel Bypass techniques circumvent the networking stack
 		\item Allows using an alternative implementation of the network stack, entirely running in userspace
 			\begin{itemize}
-				\item For use-case optimised scenarios
+				\item For use-case optimized scenarios
 			\end{itemize}
 		\item DPDK : Data Plane Development Kit
 			\begin{itemize}
@@ -459,7 +459,7 @@
 
 \begin{frame}{Netdev community}
 	\begin{itemize}
-		\item The networking stack is made of around 1M lines, 7000 distinct files
+		\item The networking stack is made up of around 1M lines, 7000 distinct files
 		\item 4 Maintainers share the top-level load :
 			\begin{itemize}
 				\item Jakub Kicinski, David S. Miller, Eric Dumazet and Paolo Abeni

--- a/slides/networking-traffic-control/networking-traffic-control.tex
+++ b/slides/networking-traffic-control/networking-traffic-control.tex
@@ -3,8 +3,8 @@
 \begin{frame}{Packet Scheduling}
 	\begin{itemize}
 		\item On complex systems, thousands of applications may use the same interface
-		\item The scheduling of egress traffic needs to be configurable and predicatble
-		\item Queueing strategies can be tunes for \textbf{throughput} and \textbf{latency}
+		\item The scheduling of egress traffic needs to be configurable and predictable
+		\item Queueing strategies can be tuned for \textbf{throughput} and \textbf{latency}
 		\item \textbf{tc} is the main component that deals with traffic scheduling
 	\end{itemize}
 \end{frame}
@@ -38,7 +38,7 @@
 \begin{frame}{TC use-cases}
 	\begin{itemize}
 		\item \code{tc mqprio} - Assign priorities to the Network Controller's queues
-		\item \code{tc taprio} - Time-aware queue priorisation, for TSN
+		\item \code{tc taprio} - Time-aware queue prioritization, for TSN
 		\item \code{tc flower} - Flow-based actions, can be offloaded to hardware
 		\item \code{tc ingress} - Attach TC actions to ingress traffic
 	\end{itemize}
@@ -48,15 +48,15 @@
 	\begin{itemize}
 		\item Controls how traffic is enqueued, in the \textbf{tx} direction
 		\item Allows shaping the traffic very precisely on a per flow basis
-		\item \textbf{Flows} can be assigned different \textbf{Qdisc} to define how to schedule transmission
+		\item \textbf{Flows} can be assigned to different \textbf{Qdisc} to define how to schedule transmission
 	\end{itemize}
 \end{frame}
 
 \begin{frame}{Queues}
 	\begin{itemize}
-		\item Queue management is crucial for Lantency and Throughput
-		\item Long queues allows absorbing network instabilities...
-		\item ... but may cause to latencies, leading to \textbf{bufferbloat}
+		\item Queue management is crucial for Latency and Throughput
+		\item Long queues allow absorbing network instabilities...
+		\item ... but may cause latencies, leading to \textbf{bufferbloat}
 		\item The Network Interface's queues are exposed to TC
 		\item \textbf{qdisc} algorithms select which queue is used for a given \textbf{flow}
 	\end{itemize}
@@ -76,11 +76,11 @@
 			\end{itemize}
 		\item The \textbf{vlan id}, if applicable, may be included in the flow definition
 			\begin{itemize}
-				\item FLows may thefore be \textbf{3-tuple} or \textbf{5-tuple}
+				\item Flows may therefore be \textbf{3-tuple} or \textbf{5-tuple}
 			\end{itemize}
 		\item When acting on a packet, we need to identify the \textbf{flow} it belongs to :
 		\item This is called \textbf{n-tuple classification}. The \code{n-tuple} is extracted, and its \textbf{hash} is computed
-		\item Extracting the \code{n-tuple} value from a packet is called \textbf{bissection}
+		\item Extracting the \code{n-tuple} value from a packet is called \textbf{bisection}
 		\item The hash is used for the subsequent lookup operations, and may be computed in hardware.
 	\end{itemize}
 \end{frame}
@@ -92,7 +92,7 @@
 		\column{0.7\textwidth}
 		\begin{itemize}
 			\item Queueing Disciplines, or \textbf{qdisc}, allow configuring the queue policy
-			\item Multiple qdisc can co-exist, separated in diffent \textbf{classes}
+			\item Multiple qdisc can co-exist, separated into different \textbf{classes}
 			\item \textbf{classes} are used to split traffic, and enforce policing
 			\item Traffic is assigned to classes through \textbf{classification}
 		\end{itemize}
@@ -155,8 +155,8 @@ action skbedit priority 6
 		\includegraphics[width=0.8\textwidth]{slides/networking-traffic-control/txq_mq.pdf}
 	\column{0.7\textwidth}
 	\begin{itemize}
-		\item Most Network Controllers today have mutilple queues in \code{tx} and \code{rx}
-		\item They implement in hardware a \textbf{policing} algorithmm to select the next \code{tx} queue to use
+		\item Most Network Controllers today have multiple queues in \code{tx} and \code{rx}
+		\item They implement in hardware a \textbf{policing} algorithm to select the next \code{tx} queue to use
 			\begin{itemize}
 				\item It can be a simple \textbf{weighted round robin} algorithm
 				\item Alternatively a \textbf{strict priority} selection
@@ -175,9 +175,9 @@ action skbedit priority 6
 \begin{frame}{TC offloads}
 	\begin{itemize}
 		\item Some TC operations can be offloaded to the Ethernet Controler, if supported
-		\item \code{tc mqprio} - The Hardware will implement the queue-selectin algorithm
+		\item \code{tc mqprio} - The Hardware will implement the queue-selection algorithm
 		\item \code{tc taprio} - For TSN-enabled hardware
-		\item \code{tc flower} - Classication in \textbf{ingress} is done by hardware
+		\item \code{tc flower} - Classification in \textbf{ingress} is done by hardware
 	\end{itemize}
 \end{frame}
 


### PR DESCRIPTION
I have read and reviewed the `networking-slides.pdf`. I am sharing the spelling mistakes that I found.

**Warning**: Be aware that I may have introduced errors: For some fixes, I am not 100% confident...

I also have the following remarks:
 - p26 Transport Layer -> "Can batch Acknowledgments, supports encryption (i think)" <= Yes? : https://en.wikipedia.org/wiki/QUIC#Characteristics
 - p130 struct net_offload -> "L2 and L3 headers are added, and a shorter L4 header" <= Maybe reformulate (I may not understand it)?
 - p198 XDP_TX -> I suppose by modifying first the destination IP? => The packet is modified, right? Or there is a special rules in the switch?
 - p233 Netdev features -> Maybe talk about "vlan_features"?