### PR TITLE
labs: bbb: drop warning about U-Boot flashed by SD-card being outdated

### DIFF
--- a/lab-data/common/bootloader/beaglebone-black/README.md
+++ b/lab-data/common/bootloader/beaglebone-black/README.md
@@ -14,7 +14,7 @@ http://beagleboard.org/latest-images and follow instructions.
 1. [Download the images](#1-download-the-images)
 2. Flash using either option:
 	1. [Flash the image using Ethernet over USB with 'snagboot'](#2i-flash-the-image-using-ethernet-over-usb) (**recommended**)
-	2. [Flash the image using a micro-SD card](#2ii-flash-the-image-using-a-micro-sd-card) (legacy)
+	2. [Flash the image using a micro-SD card](#2ii-flash-the-image-using-a-micro-sd-card)
 3. How images were built
 	1. [How snagboot images were built](#3i-how-the-binaries-were-compiled-for-snagboot-recovery)
 	2. [How the images for SD card recovery were built](#3ii-how-the-binaries-were-compiled-for-sd-card-recovery)
@@ -92,9 +92,6 @@ Don't forget to exit the shell created by the am335x setup script, as
 failing to do so may result in network issues later.
 
 ### 2.ii. Flash the image using a micro-SD card
-
-These instructions are given as reference only, they will install an old
-U-Boot. Prefer using method 2a using Snagboot.
 
 #### Make a bootable micro-SD card
 


### PR DESCRIPTION
This warning is false since 054b2ffa ("lab-data:bbb-recovery: align sdcard u-boot.img.final to snagboot's"):

> Micro sd card recovery flash an old u-boot (u-boot.img.final, v2018.05)
> on the eMMC. Bump u-boot.final to align it with u-boot used by snagboot
> recovery.

We still keep the bold "(recommended)" string for the snagboot procedure in the document's introduction section.

A trainee was facing issues with snagboot (missing udev rules) and indicated being hesitant on trying this alternative approach. Trying the SD-card method might have unlocked him and allowed him to move forward in the kernel training labs.