### PR TITLE
Makefile: Simplify agendas generation

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -243,21 +243,14 @@ endif
 #
 # === Compilation of agendas ===
 #
-ifdef AGENDA
-AGENDA_TEX = agenda/$(AGENDA)-agenda.tex
 AGENDA_PICTURES = $(COMMON_PICTURES) $(call PICTURES,agenda)
 
-%-agenda.pdf: common/agenda_old.sty common/agenda.sty $(AGENDA_TEX) $(AGENDA_PICTURES) $(OUTDIR)/last-update.tex
+%-agenda.pdf: common/agenda_old.sty common/agenda.sty agenda/%-agenda.tex $(AGENDA_PICTURES) $(OUTDIR)/last-update.tex
 	rm -f $(OUTDIR)/$(basename $@).tex
 	cp $(filter %-agenda.tex,$^) $(OUTDIR)/$(basename $@).tex
 	(cd $(OUTDIR); $(PDFLATEX_ENV) $(PDFLATEX) $(basename $@).tex)
 	(cd $(OUTDIR); $(PDFLATEX_ENV) $(PDFLATEX) $(basename $@).tex > /dev/null 2>&1)
 	cat $(OUTDIR)/$@ > $@
-else
-FORCE:
-%-agenda.pdf: FORCE
-	@$(MAKE) $@ AGENDA=$*
-endif
 
 #
 # === Last update file generation ===


### PR DESCRIPTION
Use a pattern rule for the agendas instead of a call to a sub-make, since the only prerequisite specific to an agenda can be expressed with a pattern.

This fixes the parallel generation of the prerequisites of the agendas.

Comparing the resulting pdfs with [diff-pdf](https://github.com/vslavik/diff-pdf) shows no difference.
