### PR TITLE
Removed one '../' on ipcalc meson command

### DIFF
--- a/labs/sysdev-thirdparty/sysdev-thirdparty.tex
+++ b/labs/sysdev-thirdparty/sysdev-thirdparty.tex
@@ -1067,7 +1067,7 @@ $ cd cross-build
 We can now have \code{meson} create the Ninja build files for us:
 
 \begin{bashinput}
-$ meson --cross-file ../../cross-file.txt --prefix /usr ..
+$ meson --cross-file ../cross-file.txt --prefix /usr ..
 \end{bashinput}
 
 We are now ready to build {\em ipcalc}:


### PR DESCRIPTION
There is one extra `../` in the ipcalc meson command.
It does not make sense to have two `../..` since the `cross-file.txt` is only one level above according to preceding commands.