### PR TITLE
github: update fedora version in container

### DIFF
--- a/.github/actions/build-material-action/Dockerfile
+++ b/.github/actions/build-material-action/Dockerfile
@@ -1,4 +1,4 @@
-FROM fedora:34
+FROM fedora:44
 
 LABEL maintainer="Bootlin <feedback@bootlin.com>" \
       vendor="Bootlin" \
@@ -28,10 +28,13 @@ RUN dnf -y update && \
 	texlive-epstopdf \
 	texlive-eurosym \
 	texlive-collection-fontsextra \
+	texlive-enumitem \
+	texlive-hypcap \
 	texlive-hyphenat \
 	texlive-inconsolata \
 	texlive-lstaddons \
 	texlive-ltablex \
+	texlive-marvosym \
 	texlive-mdframed \
 	texlive-moreverb \
 	texlive-overpic \
@@ -48,7 +51,8 @@ RUN dnf -y update && \
 	texlive-fmtcount \
 	texlive-babel-english \
 	texlive-babel-french \
-	texlive-appendixnumberbeamer
+	texlive-appendixnumberbeamer \
+	which
 
 ARG TYPST_VERSION=0.14.2
 RUN curl -fsSL https://github.com/typst/typst/releases/download/v${TYPST_VERSION}/typst-x86_64-unknown-linux-musl.tar.xz \


### PR DESCRIPTION
As we want to improve our build workflow, we need for example to make dia output SVG files that we can embed directly to our new typst training materials. However some pictures, like mtd-architecture.dia, embed some png files, and DIA is currently unable to generate correctly the corresponding SVG file, because of some missing gdk pixbuf2 png loader. Such loader does not seem to be available in Fedora 34, but is available in Fedora 44. Fedora 34 is now pretty old (~5 years), so update the container to the most recent version.