### PR TITLE
github: install custom dia version

### DIFF
--- a/.github/actions/build-material-action/Dockerfile
+++ b/.github/actions/build-material-action/Dockerfile
@@ -10,18 +10,29 @@ ENTRYPOINT ["/build_materials.sh"]
 
 RUN dnf -y update && \
     dnf -y install \
+	appstream-devel \
 	curl \
-	dia \
+	desktop-file-utils \
 	fakeroot \
+	g++ \
+	gcc \
 	ghostscript \
 	git \
+	glib2-devel \
+	graphene-devel \
+	gtk3-devel \
 	ImageMagick \
 	inkscape \
 	levien-inconsolata-fonts \
 	liberation-serif-fonts \
 	liberation-sans-fonts \
 	liberation-mono-fonts \
+	libxml2-devel \
+	libzip-devel \
 	make \
+	meson \
+	ninja-build \
+	python3-devel \
 	python3-pygments \
 	rsync \
 	texlive-beamer \
@@ -54,6 +65,17 @@ RUN dnf -y update && \
 	texlive-babel-french \
 	texlive-appendixnumberbeamer \
 	which
+
+ARG DIA_REVISION=3ce95975211707efe15d936923a2ae62433f27ec
+RUN git clone https://gitlab.gnome.org/GNOME/dia.git /tmp/dia && \
+    cd /tmp/dia && \
+    git checkout ${DIA_REVISION} && \
+    meson setup build --prefix=/usr/local --buildtype=release && \
+    meson compile -C build && \
+    meson install -C build && \
+    echo "/usr/local/lib64" > /etc/ld.so.conf.d/dia.conf && \
+    ldconfig && \
+    rm -rf /tmp/dia
 
 ARG TYPST_VERSION=0.14.2
 RUN curl -fsSL https://github.com/typst/typst/releases/download/v${TYPST_VERSION}/typst-x86_64-unknown-linux-musl.tar.xz \


### PR DESCRIPTION
The version of Dia packaged in Fedora, even on recent Fedora releases (44) is super old: it targets the 0.97.3 which has been released in 2014 ([1], [2]). This version brings some issues in the container, like not being able to correctly embed PNG files when exporting diagrams to SVG. Dia is still receiving update and fixes though, even if there's no official release, and those newer versions do not expose the same bug and are capable of outputing correct SVG files.

One possibility to fix this issue could be to bisect the dia project to identify when the SVG export broke (or started working again ?), but:
- the base version is super old
- there are some major changes in between, like the whole build system having switched to meson

Rather than keeping on using this old version, build and install a fresher version of dia. Use the same version as the one currently targeted by the dia-git package exposed by Archlinux, as multiple Bootlin trainers are already successfully using this version to build training materials ([3], [4]). The custom build involve some additional development tools installation. It also needs some ldconfig update, as dia is vendoring its own libxml2

[1] https://src.fedoraproject.org/rpms/dia/blob/rawhide/f/dia.spec
[2] https://gitlab.gnome.org/GNOME/dia/-/commit/9f4220c0ba97239be45fbdd6b5138305e5c5db3e
[3] https://aur.archlinux.org/cgit/aur.git/commit/PKGBUILD?h=dia-git&id=86cb4af3f8fccb8b36961e6e1973fb1e5ac74dd5
[3] https://gitlab.gnome.org/GNOME/dia/-/commit/3ce95975211707efe15d936923a2ae62433f27ec