### PR TITLE
yocto: remove invalid versioned DEPENDS example

### DIFF
--- a/slides/yocto-recipe-basics/yocto-recipe-basics.typ
+++ b/slides/yocto-recipe-basics/yocto-recipe-basics.typ
@@ -332,8 +332,6 @@ LIC_FILES_CHKSUM = "file://${COMMON_LICENSE_DIR}/MIT;md5=083..."
 
 - `bitbake` allows to reflect this by using:
 
-  - `DEPENDS = "recipe-b (>= 1.2)"`
-
   - `RDEPENDS:$PN = "recipe-b (>= 1.2)"`
 
 - The following operators are supported: `=`, `>`, `<`, `>=` and `<=`.


### PR DESCRIPTION
I'm not entirely sure about that, but I believe that the version constraints are not supported for `DEPENDS` since they are applied at the package management level rather than for build-time dependencies.

Therefore - remove invalid example from the slides.

I tried adding a dummy dependency with `DEPENDS += "<pkg> (= <invalid version>)"` and the recipe built fine, with the `<invalid version>` appearantly being ignored