### PR TITLE
Security: slides: Fix typst formatting

### DIFF
--- a/slides/security-compliance/security-compliance.typ
+++ b/slides/security-compliance/security-compliance.typ
@@ -212,7 +212,7 @@
 
   `a formal record containing details and supply chain relationships of
 components included in the software elements of a product with
-digital elements; a commonly used and machine-readable format covering 
+digital elements; a commonly used and machine-readable format covering
 at the very least the top-level dependencies of the products
   `
 

--- a/slides/security-confidential-information/security-confidential-information.typ
+++ b/slides/security-confidential-information/security-confidential-information.typ
@@ -135,7 +135,7 @@
 
 - The specification includes
   #link(
-    "https://github.com/oasis-tcs/pkcs11/tree/pkcs11-3.00/published/3-00"
+    "https://github.com/oasis-tcs/pkcs11/tree/pkcs11-3.00/published/3-00",
   )[C header files]
 
 - It is then up to token manufacturers to implement the API
@@ -192,35 +192,33 @@ Below are some examples of functions declared in the `pkcs11f.h` header:
 
 - The "vendor" module is optee_client's
   #link(
-    "https://github.com/OP-TEE/optee_client/tree/master/libckteec"
+    "https://github.com/OP-TEE/optee_client/tree/master/libckteec",
   )[`libckteec.so`]
 
 - Requires the TA to be loaded in OP-TEE
 
-  - this a perfect job for the 
-    #link(
-      "https://github.com/OP-TEE/optee_client/blob/master/libckteec/src/pkcs11_api.c#L95"
-    )[`C_Initialize`] function.
+  - this a perfect job for the
+    #link("https://github.com/OP-TEE/optee_client/blob/master/libckteec/src/pkcs11_api.c#L95")[`C_Initialize`] function.
   - Ultimately, `ckteec_invoke_init` is called:
- 
+
   #[ #show raw.where(lang: "c", block: true): set text(size: 13pt)
-  ```c
-  CK_RV ckteec_invoke_init(void)                                                  
-  {                                                                               
-           TEEC_UUID uuid = PKCS11_TA_UUID;
-  ...
-           res = TEEC_InitializeContext(NULL, &ta_ctx.context);                    
-           if (res != TEEC_SUCCESS) {                                              
-                   EMSG("TEEC init context failed\n");                             
-                   rv = CKR_DEVICE_ERROR;                                          
-                   goto out;                                                       
-           }                                                                       
-                                                                                   
-           res = TEEC_OpenSession(&ta_ctx.context, &ta_ctx.session, &uuid,         
-                                  login_method, login_data, NULL, &origin);
-  ...
-  }
-  ```]
+    ```c
+    CK_RV ckteec_invoke_init(void)
+    {
+             TEEC_UUID uuid = PKCS11_TA_UUID;
+    ...
+             res = TEEC_InitializeContext(NULL, &ta_ctx.context);
+             if (res != TEEC_SUCCESS) {
+                     EMSG("TEEC init context failed\n");
+                     rv = CKR_DEVICE_ERROR;
+                     goto out;
+             }
+
+             res = TEEC_OpenSession(&ta_ctx.context, &ta_ctx.session, &uuid,
+                                    login_method, login_data, NULL, &origin);
+    ...
+    }
+    ```]
 
 == Cryptographic keys in the kernel
 <cryptographic-keys-in-the-kernel>

--- a/slides/security-fundamental-concepts/security-fundamental-concepts.typ
+++ b/slides/security-fundamental-concepts/security-fundamental-concepts.typ
@@ -378,10 +378,10 @@ Flip side of the security properties:
 #text(size: 12pt)[
   #align(center)[
     #align(center, [#image("CBC_encryption.svg", width: 80%)])
-      WhiteTimberwolf, Public domain: \
-      #link(
-        "https://commons.wikimedia.org/wiki/File:CBC_encryption.svg",
-        )[https://commons.wikimedia.org/wiki/File:CBC_encryption.svg]
+    WhiteTimberwolf, Public domain: \
+    #link(
+      "https://commons.wikimedia.org/wiki/File:CBC_encryption.svg",
+    )[https://commons.wikimedia.org/wiki/File:CBC_encryption.svg]
   ]
 ]
 
@@ -407,10 +407,10 @@ Flip side of the security properties:
 #text(size: 12pt)[
   #align(center)[
     #align(center, [#image("CTR_encryption_2.svg", width: 80%)])
-      WhiteTimberwolf, Public domain: \
-      #link(
-        "https://commons.wikimedia.org/wiki/File:CTR_encryption_2.svg",
-      )[https://commons.wikimedia.org/wiki/File:CTR_encryption_2.svg]
+    WhiteTimberwolf, Public domain: \
+    #link(
+      "https://commons.wikimedia.org/wiki/File:CTR_encryption_2.svg",
+    )[https://commons.wikimedia.org/wiki/File:CTR_encryption_2.svg]
   ]
 ]
 

--- a/slides/security-secure-boot-part-1/security-secure-boot-part-1.typ
+++ b/slides/security-secure-boot-part-1/security-secure-boot-part-1.typ
@@ -150,7 +150,7 @@
   of software. This includes:
 
   - Offline modification of the software by reflashing the boot medium.
-    
+
     This could be how an attacker gain access.
 
   - Runtime rewriting of the software (persistence).

--- a/slides/security-userland/security-userland.typ
+++ b/slides/security-userland/security-userland.typ
@@ -53,7 +53,7 @@
 
 - POSIX permissions are a typical example of a DAC based on ACLs
 
-- UNIX philosophy: everything is a file, so objects (including devices) are 
+- UNIX philosophy: everything is a file, so objects (including devices) are
   represented by files.
 
 - Files metadata include:


### PR DESCRIPTION
Fix the Typst formatting.

git pre-commit hook:

```
#!/bin/sh
# Abort the commit if any staged .typ file is not formatted per typstyle.
# Checks the staged blob (not the worktree) so unrelated edits don't interfere.

set -e

if ! command -v typstyle >/dev/null 2>&1; then
    echo "pre-commit: typstyle not found in PATH; skipping .typ format check" >&2
    exit 0
fi

# Added/Copied/Modified/Renamed, NUL-separated to handle spaces in paths.
files=$(git diff --cached --name-only --diff-filter=ACMR -z | tr '\0' '\n' | grep -E '\.typ$' || true)

[ -z "$files" ] && exit 0

bad=""
while IFS= read -r f; do
    [ -z "$f" ] && continue
    if ! git show ":$f" | typstyle --check >/dev/null 2>&1; then
        bad="$bad $f"
    fi
done <<EOF
$files
EOF

if [ -n "$bad" ]; then
    echo "pre-commit: the following staged .typ files are not formatted:" >&2
    for f in $bad; do
        printf '  %s\n' "$f" >&2
    done
    echo >&2
    echo "To fix, run:" >&2
    echo "  typstyle -i$bad" >&2
    echo "then 'git add' the files and commit again." >&2
    exit 1
fi

```