### PR TITLE
slides: first-slides: fix typo

### DIFF
--- a/slides/first-slides/first-slides.typ
+++ b/slides/first-slides/first-slides.typ
@@ -58,7 +58,7 @@
   [
     === Electronic copies of these documents
     - Electronic copies of your particular version of the materials are available on: \ #link(sessionurl)
-    - You can download and open these documents to follow lectures and labs, to look for explanations gidven earlier by the trainer and to copy and paste text during labs.
+    - You can download and open these documents to follow lectures and labs, to look for explanations given earlier by the trainer and to copy and paste text during labs.
     - This specific URL will remain available for a long time. This way, you can always access the exact instructions corresponding to the labs performed in this session.
     - If you are interested in the latest versions of our training materials, visit the description of each course on #link("https://bootlin.com/training")
   ]


### PR DESCRIPTION
Fix typo by replacing "gidven" by "given".