### PR TITLE
Fix double-dashes in commands

### DIFF
--- a/common/gdb.typ
+++ b/common/gdb.typ
@@ -193,11 +193,11 @@ A few useful GDB commands
   `gdbserver /dev/ttyS0 <executable> <args>`
 
 - Otherwise, attach `gdbserver` to an already running program:  \
-  `gdbserver –attach :<port> <pid>`
+  `gdbserver --attach :<port> <pid>`
 
 - You can also start gdbserver without passing any program to start or
   attach (and set the target program later, on client side):  \
-  `gdbserver –multi :<port>`
+  `gdbserver --multi :<port>`
 
 === Remote debugging: host setup
 
@@ -213,7 +213,7 @@ A few useful GDB commands
     `gdb> target remote /dev/ttyUSB0` (serial link)
 
     - Make sure to replace `target remote` with `target extended-remote`
-      if you have started gdbserver with the `–multi` option
+      if you have started gdbserver with the `--multi` option
 
   - If you did not set the program to debug on gdbserver commandline:  \
     `gdb> set remote exec-file <path_to_program_on_target>`

--- a/common/strace.typ
+++ b/common/strace.typ
@@ -76,4 +76,4 @@
   ```
   #v(0.5em)
 ]
-- Run `strace –tips` to learn new commands !
+- Run `strace --tips` to learn new commands !

--- a/slides/audio-pipewire/audio-pipewire.typ
+++ b/slides/audio-pipewire/audio-pipewire.typ
@@ -52,7 +52,7 @@
   [
 
     Example with `pw-play audio.wav` and
-    `pw-record –target pw-play rec.wav`:
+    `pw-record --target pw-play rec.wav`:
 
     ```text
     $ pw-cli ls Core
@@ -695,7 +695,7 @@ $ pw-config --name custom.conf paths
 
 - By default, it connects to the PipeWire daemon and creates a graph
   representation of the global objects. It can also work from the output
-  of `pw-dump` using the `–json` flag.
+  of `pw-dump` using the `--json` flag.
 
 - That file can be turned into a graphical representation and viewed on
   a host using:
@@ -711,13 +711,13 @@ $ pw-config --name custom.conf paths
 
 - It has many options available to control the exposed props and params:
 
-  - `–target` allows asking to be routed to a given node;
+  - `--target` allows asking to be routed to a given node;
 
-  - `–latency` asks for a given latency (therefore buffer size);
+  - `--latency` asks for a given latency (therefore buffer size);
 
-  - `–quality` controls the adaptive resampling;
+  - `--quality` controls the adaptive resampling;
 
-  - `–rate`, `–channels`, `–channel-map`, `–format`, `–volume` are
+  - `--rate`, `--channels`, `--channel-map`, `--format`, `--volume` are
     self-describing.
 
   - etc.
@@ -867,7 +867,7 @@ PIPEWIRE_RUNTIME_DIR=/tmp helvum
 
   - This can be done using Helvum with its GUI.
 
-  - Otherwise, `pw-dot` or `pw-link –links` to get an overview then
+  - Otherwise, `pw-dot` or `pw-link --links` to get an overview then
     `pw-link <output-port> <input-port>` to create a new link.
 
 == WirePlumber
@@ -917,7 +917,7 @@ PIPEWIRE_RUNTIME_DIR=/tmp helvum
 
 - Nodes can also request to be routed to:
 
-  + a target node using `target.object` (for example `pw-cat –target`);
+  + a target node using `target.object` (for example `pw-cat --target`);
 
   + nothing automatically using `node.autoconnect`. WirePlumber will not
     create any automatic link, letting any PipeWire client create the
@@ -1420,7 +1420,7 @@ static const struct pw_filter_events filter_events = {
 
 A dump of useful links:
 
-- For MIDI support, see `pw-cat –midi`, `pw-mididump` and
+- For MIDI support, see `pw-cat --midi`, `pw-mididump` and
   #link("https://docs.pipewire.org/page_midi.html")[the documentation].
 
 - For the PulseAudio compatibility layer, see

--- a/slides/debugging-application-profiling/debugging-application-profiling.typ
+++ b/slides/debugging-application-profiling/debugging-application-profiling.typ
@@ -110,7 +110,7 @@
 - `#`: Peak allocation
 
 - `@`: Detailed snapshot (count can be adjusted thanks to
-  `–detailed-freq`)
+  `--detailed-freq`)
 
 === Massif report
 
@@ -356,7 +356,7 @@ Performance counter stats for 'cat /etc/fstab':
 - `cg_annotate` is a CLI tool used to visualize cachegrind simulation
   results.
 
-- It also has a `–diff` option to allow comparing two measures files
+- It also has a `--diff` option to allow comparing two measures files
 
 === Kcachegrind - Visualizing Cachegrind profiling data
 

--- a/slides/debugging-kernel-debugging/debugging-kernel-debugging.typ
+++ b/slides/debugging-kernel-debugging/debugging-kernel-debugging.typ
@@ -76,7 +76,7 @@ BUILD_BUG_ON(sizeof(ctx->__reserved) != sizeof(reserved));
 - If during compilation you have some warnings about unused
   variables/parameters, they must be fixed.
 
-- Apply `checkpatch.pl –strict` when possible which might find some
+- Apply `checkpatch.pl --strict` when possible which might find some
   potential problems in your code.
 
 == Linux Kernel Debugging
@@ -768,8 +768,8 @@ KERNEL STACK SIZE: 8192
 
 - Load a dump-capture kernel on the first kernel with `kexec`:
 
-  - `kexec –type zImage -p my_zImage –dtb=my_dtb.dtb \` \
-    `–initrd=my_initrd –command-line="kernel command line"`
+  - `kexec --type zImage -p my_zImage --dtb=my_dtb.dtb \` \
+    `--initrd=my_initrd --command-line="kernel command line"`
 
 - Then simply wait for a crash to happen!
 

--- a/slides/debugging-system-wide-profiling/debugging-system-wide-profiling.typ
+++ b/slides/debugging-system-wide-profiling/debugging-system-wide-profiling.typ
@@ -1046,7 +1046,7 @@ int main(int argc, char *argv[])
   ```
 ]
 #v(0.5em)
-- Then on the target, at session creation, use the `–set-url`
+- Then on the target, at session creation, use the `--set-url`
 #v(0.5em)
 #[
   #show raw.where(lang: "console", block: true): set text(size: 15pt)

--- a/slides/networking-debugging/networking-debugging.typ
+++ b/slides/networking-debugging/networking-debugging.typ
@@ -77,9 +77,9 @@
 
   - `ethtool -S eth0`
 
-  - `ethtool –phy-statistics eth0`
+  - `ethtool --phy-statistics eth0`
 
-  - `ethtool -S eth0 –groups eth-mac|eth-phy|eth-ctrl|rmon`
+  - `ethtool -S eth0 --groups eth-mac|eth-phy|eth-ctrl|rmon`
 
 - Some information may be available in *debugfs*
 

--- a/slides/networking-driver-phy/networking-driver-phy.typ
+++ b/slides/networking-driver-phy/networking-driver-phy.typ
@@ -383,11 +383,11 @@
 
   - Detects cable and connector faults
 
-  - `ethtool –cable-test eth0`
+  - `ethtool --cable-test eth0`
 
 - They may report stats, useful for debugging link bringup
 
-  - `ethtool –phy-statistics eth0`
+  - `ethtool --phy-statistics eth0`
 
 - *`BaseT1S`* PHYs can configure the
   #link(

--- a/slides/networking-stack-control/networking-stack-control.typ
+++ b/slides/networking-stack-control/networking-stack-control.typ
@@ -167,7 +167,7 @@
   - Applications can listen for specific notifications (Address change,
     link up, etc.)
 
-  - e.g. `ip monitor`, `ethtool –monitor`, etc.
+  - e.g. `ip monitor`, `ethtool --monitor`, etc.
 
 - It is also possible to listen to *All Netlink Traffic*
 

--- a/slides/security-userland/security-userland.typ
+++ b/slides/security-userland/security-userland.typ
@@ -1024,9 +1024,9 @@ Users: 1
 
   - Filters can be added on the type of rules:
 
-    - `–allow`
+    - `--allow`
 
-    - `–role_transition`
+    - `--role_transition`
 
     - …
 
@@ -1055,11 +1055,11 @@ Users: 1
 
 - Policy modules can be dynamically loaded or unloaded with `semodule`
 
-  - `–list-modules`
+  - `--list-modules`
 
-  - `–enable`
+  - `--enable`
 
-  - `–disable`
+  - `--disable`
 
 #text(size: 13pt)[
   ```

--- a/slides/sysdev-block-filesystems/sysdev-block-filesystems.typ
+++ b/slides/sysdev-block-filesystems/sysdev-block-filesystems.typ
@@ -421,7 +421,7 @@ systems:
   disk image.
 
 - The `losetup` command allows to manually associate a loop device to a
-  file, and offers a `–partscan` option allowing to also create extra
+  file, and offers a `--partscan` option allowing to also create extra
   block device files for the partitions inside the image:
 
   ```

--- a/slides/sysdev-cross-compiling-user-space/sysdev-cross-compiling-user-space.typ
+++ b/slides/sysdev-cross-compiling-user-space/sysdev-cross-compiling-user-space.typ
@@ -367,15 +367,15 @@
 
 + *Configuration:* `./configure`
 
-  - `./configure –help` is very useful
+  - `./configure --help` is very useful
 
-  - `–prefix`: execution location
+  - `--prefix`: execution location
 
-  - `–host`: target machine when cross-compiling, if not provided,
+  - `--host`: target machine when cross-compiling, if not provided,
     auto-detected. Also used as the cross-compiler prefix.
 
-  - Often `–enable-<foo>`, `–disable-<foo>`, `–with-<foo>`,
-    `–without-<foo>` for optional features.
+  - Often `--enable-<foo>`, `--disable-<foo>`, `--with-<foo>`,
+    `--without-<foo>` for optional features.
 
   - `CC`, `CXX`, `CFLAGS`, `CXXFLAGS`, `LDFLAGS` and many more variables
 
@@ -669,7 +669,7 @@ only the C cross-compiler needs to be specified:
     - Can be created manually, or may be provided by an embedded Linux build
       systems such as Buildroot or Yocto.
 
-    - `–cross-file` option of _Meson_
+    - `--cross-file` option of _Meson_
 
   ],
   [

--- a/slides/yocto-advanced/yocto-advanced.typ
+++ b/slides/yocto-advanced/yocto-advanced.typ
@@ -484,11 +484,11 @@ KERNEL_DEVICETREE:dra7xx-evm = "dra7-evm.dtb"    # This is ignored
 
   - Force the `dropbear` recipe to run all tasks.
 
-- `bitbake –runall=fetch core-image-minimal`
+- `bitbake --runall=fetch core-image-minimal`
 
   - Download all recipe sources and their dependencies.
 
-- For a full description: `bitbake –help`
+- For a full description: `bitbake --help`
 
 === shared state cache
 

--- a/slides/yocto-recipe-advanced/yocto-recipe-advanced.typ
+++ b/slides/yocto-recipe-advanced/yocto-recipe-advanced.typ
@@ -530,7 +530,7 @@ PREMIRRORS:prepend = "\
   #yoctovar("BB_NO_NETWORK = \"1\"")
 
   - To download all the sources before disabling network access use \
-    `bitbake –runall=fetch core-image-minimal`
+    `bitbake --runall=fetch core-image-minimal`
 
 - Or restrict `bitbake` to only download files from the
   #yoctovar("PREMIRRORS"), using


### PR DESCRIPTION
The conversion to typst converted double dashes in command ('--') to single dashes. Convert them back to double dashes, by grepping through the materials with the "`.*–" regular expression.