### PR TITLE
slides: yocto: mention use of bitbake-getvar -r sooner

### DIFF
--- a/slides/yocto-advanced/yocto-advanced.typ
+++ b/slides/yocto-advanced/yocto-advanced.typ
@@ -226,10 +226,13 @@
 - `bitbake-getvar` can be used to understand and debug how variables are
   assigned
 
-- `bitbake-getvar <VARIABLE>`
-
 - Lists each configuration file touching the variable, the pre-expansion
   value and the final value
+
+- `bitbake-getvar <VARIABLE>`: dump the variable value in the *global* scope
+
+- `bitbake-getvar -r <recipe> <VARIABLE>`: dump the variable value in the
+  *local* scope of `recipe`
 
 #v(0.5em)
 

--- a/slides/yocto-recipe-basics/yocto-recipe-basics.typ
+++ b/slides/yocto-recipe-basics/yocto-recipe-basics.typ
@@ -581,9 +581,9 @@ SRC_URI[sha256sum] = "731140004fdb6..."
 
 - These can be inspected to understand what is being done by the tasks
 
-=== Debugging variable assignment
+=== Debugging variable assignments
 
-- `bitbake-getvar` can dump the per-recipe variable value using the `-r`
+- (Reminder) `bitbake-getvar` can dump the per-recipe variable value using the `-r`
   option
 
   - `bitbake-getvar -r ncurses SRC_URI`
@@ -591,6 +591,6 @@ SRC_URI[sha256sum] = "731140004fdb6..."
 - Similarly, `bitbake -e` dumps the entire environment, and also the
   task code
 
-  - `bitbake -e`
+  - `bitbake -e` (*global* environment)
 
-  - `bitbake -e ncurses`
+  - `bitbake -e ncurses` (environment of `ncurses`)


### PR DESCRIPTION
We already introduce the notion of global and local scope earlier in the "Variables" section. With 8997911c5a99 ("yocto: slides: present bitbake-getvar earlier"), the bitbake-getvar utility was introduced to this section, but without mentions of the `-r` argument, which is useful to illustrate the difference between the local and global scopes.

Later in the slides we talk about bitbake-getvar again, to lead into the presentation of the `-e` flag. Just add a "(Reminder)" there and detail the difference between single `-e` and `-e` for a recipe.